### PR TITLE
Выбор объекта event

### DIFF
--- a/vkbottle/framework/rule/rule.py
+++ b/vkbottle/framework/rule/rule.py
@@ -142,7 +142,8 @@ class EventRule(AbstractRule):
         self.data = {"event": event}
 
     async def check(self, event):
-        self.data["data"] = self.getfullargspec.annotations.get(self.getfullargspec.args[0], dict)
+        if "data" not in self.data:
+            self.data["data"] = self.getfullargspec.annotations.get(self.getfullargspec.args[0], dict)
         for e in self.data["event"]:
             if e == event:
                 return True


### PR DESCRIPTION
Теперь можно указать объект типом первого аргумента

from vkbottle.types.events.community.events_objects import WallPostNew

@bot.on.event('wall_post_new')
async def _(event: WallPostNew):
 print(event, type(event))

P.S. Возможно, можно сделать проще (только что посмотрел как достать типы аргументов функции), но идею я подал