### PR TITLE
Dataclass, а не dict

### DIFF
--- a/vkbottle/types/objects/wall.py
+++ b/vkbottle/types/objects/wall.py
@@ -109,7 +109,7 @@ class Views(BaseModel):
 
 
 class WallComment(BaseModel):
-    attachments: typing.List = None
+    attachments: typing.List[CommentAttachment] = None
     date: int = None
     from_id: int = None
     id: int = None


### PR DESCRIPTION
`attachments` в `WallComment` будет приходить не списком словарей, а списком датаклассов `CommentAttachment`