### PR TITLE
Фикс списков и кортежей в request`ах

### DIFF
--- a/vkbottle/api/api/api.py
+++ b/vkbottle/api/api/api.py
@@ -65,9 +65,14 @@ class API(ContextInstanceMixin):
         self.wall = Wall(self.api)
         self.widgets = Widgets(self.api)
 
-    def api(self, *args, **kwargs):
+    def api(self, method, params, **kwargs):
+
+        for k, v in params.items():
+            if isinstance(v, (tuple, list)):
+                params[k] = ','.join(repr(i) for i in v)
+
         request = Request(self.token_generator)
-        return request(*args, **kwargs)
+        return request(method, params, **kwargs)
 
     async def request(
         self,


### PR DESCRIPTION
Это та системка, которая преобразует списки и кортежи в строку, так как запрос к вк апи не может их нормально обработать без багов (когда в запрос посылаешь список id пользователей, в ответе приходит только результат с последним id в списке)