### PR TITLE
Перемещение secret туда, где ему самое место

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ bot.run_polling(skip_updates=False)
 from vkbottle import Bot, Message
 from aiohttp import web
 
-bot = Bot(token="my-token", secret="my-secret")
+bot = Bot(token="my-token")
 app = web.Application()
 
 
 async def executor(request: web.Request):
     event = await request.json()
-    emulation = await bot.emulate(event=event, confirmation_token="ConfirmationToken")
+    emulation = await bot.emulate(event=event, secret="my_secret", confirmation_token="my_confirmation")
     return web.Response(text=emulation)
 
 

--- a/examples/callback_bot.py
+++ b/examples/callback_bot.py
@@ -4,13 +4,13 @@ from vkbottle import Bot
 
 app = Application()
 routes = RouteTableDef()
-bot = Bot("my-token", secret="SecretKey")
+bot = Bot("my-token")
 
 
 @routes.get("/bot")
 async def executor(request: Request):
     return await bot.emulate(
-        event=dict(request.query), confirmation_token="ConfirmationToken"
+        event=dict(request.query), secret="my_secret", confirmation_token="my_confirmation"
     )
 
 


### PR DESCRIPTION
Так как secret key и confirmation code используются только при callback-е, значит логичнее будет передавать их в функцию emulate. А не задавать secret key в конструкторе, а confirmation code передавать в функцию.