### PR TITLE
Порядок правил

### DIFF
--- a/vkbottle/framework/framework/handler/message.py
+++ b/vkbottle/framework/framework/handler/message.py
@@ -153,11 +153,13 @@ class ABCMessageHandler(ABC):
         """
 
         def decorator(func):
-            current: typing.List[AbstractRule] = list(rules)
-            current.extend(self._col_rules(**col_rules))
+            current: typing.List[AbstractRule] = []
 
             if text:
                 current.append(self._text_rule(func, text, lower, command, "{}$"))
+
+            current.extend(rules)
+            current.extend(self._col_rules(**col_rules))
 
             self.add_rules(current, func)
             return func

--- a/vkbottle/framework/framework/handler/message.py
+++ b/vkbottle/framework/framework/handler/message.py
@@ -110,13 +110,15 @@ class ABCMessageHandler(ABC):
         :param pattern: any regex pattern pattern. {} means text which will be formatted
         :return: True
         """
-        current: typing.List[AbstractRule] = list(rules)
-        current.extend(self._col_rules(**col_rules))
+        current: typing.List[AbstractRule] = []
 
         if text:
             current.append(
                 self._text_rule(func, text, lower, command, pattern or "{}$")
             )
+
+        current.extend(rules)
+        current.extend(self._col_rules(**col_rules))
 
         self.add_rules(current, func)
 


### PR DESCRIPTION
Изменил порядок добавления правил, теперь:
`text_rule`-> `rules`-> `col_rules`
Было:
`rules`-> `col_rules`-> `text_rule`
И для команд, которые имели правило `is_admin` (к примеру) выполнялась эта проверка раньше чем проверка на правильность написания команды, что не имело смысл.