### PR TITLE
Хэш для моделей и их сравнение

### DIFF
--- a/vkbottle/types/objects/apps.py
+++ b/vkbottle/types/objects/apps.py
@@ -13,6 +13,12 @@ class AppMin(BaseModel):
     icon_278: str = None
     icon_75: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class App(AppMin):
     author_group: int = None

--- a/vkbottle/types/objects/audio.py
+++ b/vkbottle/types/objects/audio.py
@@ -27,11 +27,23 @@ class AudioAlbum(BaseModel):
     access_key: str = None
     thumb: AlbumThumb = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class Artist(BaseModel):
     name: str = None
     domain: str = None
     id: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class Audio(BaseModel):
@@ -51,6 +63,12 @@ class Audio(BaseModel):
     genre_id: int = None
     performer: str = None
     main_artists: List[Artist] = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 Audio.update_forward_refs()

--- a/vkbottle/types/objects/base.py
+++ b/vkbottle/types/objects/base.py
@@ -10,6 +10,12 @@ class City(BaseModel):
     id: int = None
     title: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class CommentsInfo(BaseModel):
     can_post: "BoolInt" = None
@@ -20,6 +26,12 @@ class CommentsInfo(BaseModel):
 class Country(BaseModel):
     id: int = None
     title: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class Error(BaseModel):
@@ -67,6 +79,12 @@ class Object(BaseModel):
     id: int = None
     title: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class ObjectCount(BaseModel):
     count: int = None
@@ -75,6 +93,12 @@ class ObjectCount(BaseModel):
 class ObjectWithName(BaseModel):
     id: int = None
     name: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class OkResponse(IntEnum):
@@ -93,6 +117,12 @@ class Place(BaseModel):
     longitude: float = None
     title: str = None
     type: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class PropertyExists(IntEnum):
@@ -120,6 +150,12 @@ class Sticker(BaseModel):
     images_with_background: typing.List = None
     product_id: int = None
     sticker_id: int = None
+
+    def __hash__(self):
+        return hash((self.product_id, self.sticker_id))
+
+    def __eq__(self, other):
+        return self.product_id == other.product_id and self.sticker_id == other.sticker_id
 
 
 class UploadServer(BaseModel):

--- a/vkbottle/types/objects/board.py
+++ b/vkbottle/types/objects/board.py
@@ -14,6 +14,12 @@ class Topic(BaseModel):
     updated: int = None
     updated_by: int = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class TopicComment(BaseModel):
     attachments: typing.List = None

--- a/vkbottle/types/objects/database.py
+++ b/vkbottle/types/objects/database.py
@@ -12,15 +12,33 @@ class Faculty(BaseModel):
     id: int = None
     title: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class Region(BaseModel):
     id: int = None
     title: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class School(BaseModel):
     id: int = None
     title: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class Station(BaseModel):
@@ -29,10 +47,22 @@ class Station(BaseModel):
     id: int = None
     name: str = None
 
+    def __hash__(self):
+        return hash((self.city_id, self.id))
+
+    def __eq__(self, other):
+        return self.city_id == other.city_id and self.id == other.id
+
 
 class University(BaseModel):
     id: int = None
     title: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 City.update_forward_refs()

--- a/vkbottle/types/objects/docs.py
+++ b/vkbottle/types/objects/docs.py
@@ -17,6 +17,12 @@ class Doc(BaseModel):
     type: int = None
     url: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class DocAttachmentType(Enum):
     doc = "doc"

--- a/vkbottle/types/objects/fave.py
+++ b/vkbottle/types/objects/fave.py
@@ -42,6 +42,12 @@ class Tag(BaseModel):
     id: int = None
     name: str = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 Bookmark.update_forward_refs()
 Page.update_forward_refs()

--- a/vkbottle/types/objects/friends.py
+++ b/vkbottle/types/objects/friends.py
@@ -10,6 +10,12 @@ class FriendStatus(BaseModel):
     sign: str = None
     user_id: int = None
 
+    def __hash__(self):
+        return hash(self.user_id)
+
+    def __eq__(self, other):
+        return self.user_id == other.user_id
+
 
 class FriendsList(BaseModel):
     id: int = None
@@ -21,11 +27,23 @@ class MutualFriend(BaseModel):
     common_friends: typing.List = None
     id: int = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class Requests(BaseModel):
     _from: str = None
     mutual: "RequestsMutual" = None
     user_id: int = None
+
+    def __hash__(self):
+        return hash(self.user_id)
+
+    def __eq__(self, other):
+        return self.user_id == other.user_id
 
 
 class RequestsMutual(BaseModel):
@@ -38,6 +56,12 @@ class RequestsXtrMessage(BaseModel):
     message: str = None
     mutual: "RequestsMutual" = None
     user_id: int = None
+
+    def __hash__(self):
+        return hash(self.user_id)
+
+    def __eq__(self, other):
+        return self.user_id == other.user_id
 
 
 FriendStatus.update_forward_refs()

--- a/vkbottle/types/objects/gifts.py
+++ b/vkbottle/types/objects/gifts.py
@@ -11,6 +11,12 @@ class Gift(BaseModel):
     message: str = None
     privacy: "GiftPrivacy" = None
 
+    def __hash__(self):
+        return hash((self.from_id, self.id))
+
+    def __eq__(self, other):
+        return self.from_id == other.from_id and self.id == other.id
+
 
 class GiftPrivacy(IntEnum):
     visible_name_and_message = 0
@@ -23,6 +29,12 @@ class Layout(BaseModel):
     thumb_256: str = None
     thumb_48: str = None
     thumb_96: str = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 Gift.update_forward_refs()

--- a/vkbottle/types/objects/groups.py
+++ b/vkbottle/types/objects/groups.py
@@ -173,6 +173,12 @@ class Group(BaseModel):
     start_date: int = None
     type: "GroupType" = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class GroupBanInfo(BaseModel):
     comment: str = None

--- a/vkbottle/types/objects/market.py
+++ b/vkbottle/types/objects/market.py
@@ -16,6 +16,12 @@ class MarketAlbum(BaseModel):
     title: str = None
     updated_time: int = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class MarketCategory(BaseModel):
     id: int = None
@@ -38,6 +44,12 @@ class MarketItem(BaseModel):
     thumb_photo: str = None
     title: str = None
     url: str = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class MarketItemFull(MarketItem):

--- a/vkbottle/types/objects/messages.py
+++ b/vkbottle/types/objects/messages.py
@@ -29,6 +29,12 @@ class AudioMessage(BaseModel):
     transcript_state: str = None
     waveform: typing.List[int] = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class Call(BaseModel):
     initiator_id: int = None
@@ -52,6 +58,12 @@ class Chat(BaseModel):
     type: str = None
     users: typing.List[int] = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class ChatFull(BaseModel):
     admin_id: int = None
@@ -65,6 +77,12 @@ class ChatFull(BaseModel):
     title: str = None
     type: str = None
     users: typing.List[int] = None
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
 
 
 class ChatPushSettings(BaseModel):
@@ -104,6 +122,12 @@ class ConversationMember(BaseModel):
     request_date: int = None
     member_id: int = None
 
+    def __hash__(self):
+        return hash(self.member_id)
+
+    def __eq__(self, other):
+        return self.member_id == other.member_id
+
 
 class ConversationPeer(BaseModel):
     id: int = None
@@ -136,6 +160,12 @@ class ForeignMessage(BaseModel):
     text: str = None
     update_time: int = None
 
+    def __hash__(self):
+        return hash((self.from_id, self.id))
+
+    def __eq__(self, other):
+        return self.from_id == other.from_id and self.id == other.id
+
 
 class Graffiti(BaseModel):
     access_key: str = None
@@ -145,11 +175,23 @@ class Graffiti(BaseModel):
     url: str = None
     width: int = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class HistoryAttachment(BaseModel):
     attachment: "HistoryMessageAttachment" = None
     message_id: int = None
     from_id: int = None
+
+    def __hash__(self):
+        return hash((self.from_id, self.message_id))
+
+    def __eq__(self, other):
+        return self.from_id == other.from_id and self.message_id == other.message_id
 
 
 class HistoryMessageAttachment(BaseModel):
@@ -242,6 +284,12 @@ class Message(BaseModel):
     reply_message: "ForeignMessage" = None
     text: str = None
     update_time: int = None
+
+    def __hash__(self):
+        return hash((self.from_id, self.id))
+
+    def __eq__(self, other):
+        return self.from_id == other.from_id and self.id == other.id
 
     def get_photo_attachments(self) -> typing.List["photos.Photo"]:
         return [attachment.photo for attachment in self.attachments if attachment.photo]
@@ -351,6 +399,12 @@ class PinnedMessage(BaseModel):
     reply_message: "ForeignMessage" = None
     text: str = None
     keyboard: "Keyboard" = None
+
+    def __hash__(self):
+        return hash((self.from_id, self.id))
+
+    def __eq__(self, other):
+        return self.from_id == other.from_id and self.id == other.id
 
 
 class UserXtrInvitedBy(users.UserXtrType):

--- a/vkbottle/types/objects/notes.py
+++ b/vkbottle/types/objects/notes.py
@@ -14,6 +14,12 @@ class Note(BaseModel):
     title: str = None
     view_url: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class NoteComment(BaseModel):
     date: int = None

--- a/vkbottle/types/objects/pages.py
+++ b/vkbottle/types/objects/pages.py
@@ -15,6 +15,12 @@ class Wikipage(BaseModel):
     who_can_edit: int = None
     who_can_view: int = None
 
+    def __hash__(self):
+        return hash((self.group_id, self.id))
+
+    def __eq__(self, other):
+        return self.group_id == other.group_id and self.id == other.id
+
 
 class WikipageFull(BaseModel):
     created: int = None
@@ -32,6 +38,12 @@ class WikipageFull(BaseModel):
     views: int = None
     who_can_edit: int = None
     who_can_view: int = None
+
+    def __hash__(self):
+        return hash((self.group_id, self.id))
+
+    def __eq__(self, other):
+        return self.group_id == other.group_id and self.id == other.id
 
 
 class WikipageHistory(BaseModel):

--- a/vkbottle/types/objects/photos.py
+++ b/vkbottle/types/objects/photos.py
@@ -95,6 +95,12 @@ class PhotoAlbum(BaseModel):
     title: str = None
     updated: int = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class PhotoAlbumFull(BaseModel):
     can_upload: "base.BoolInt" = None
@@ -111,6 +117,12 @@ class PhotoAlbumFull(BaseModel):
     title: str = None
     updated: int = None
     upload_by_admins_only: "base.BoolInt" = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class PhotoFull(BaseModel):
@@ -132,6 +144,12 @@ class PhotoFull(BaseModel):
     text: str = None
     user_id: int = None
     width: int = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class PhotoFullXtrRealOffset(BaseModel):
@@ -161,6 +179,12 @@ class PhotoFullXtrRealOffset(BaseModel):
     text: str = None
     user_id: int = None
     width: int = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class PhotoSizes(BaseModel):
@@ -222,6 +246,12 @@ class PhotoXtrRealOffset(BaseModel):
     text: str = None
     user_id: int = None
     width: int = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class PhotoXtrTagInfo(BaseModel):

--- a/vkbottle/types/objects/polls.py
+++ b/vkbottle/types/objects/polls.py
@@ -19,6 +19,12 @@ class Poll(BaseModel):
     question: str = None
     votes: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class Voters(BaseModel):
     answer_id: int = None

--- a/vkbottle/types/objects/stories.py
+++ b/vkbottle/types/objects/stories.py
@@ -44,6 +44,12 @@ class Story(BaseModel):
     can_ask: "base.BoolInt" = None
     can_ask_anonymous: "base.BoolInt" = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class StoryLink(BaseModel):
     text: str = None

--- a/vkbottle/types/objects/users.py
+++ b/vkbottle/types/objects/users.py
@@ -212,6 +212,12 @@ class UserMin(BaseModel):
     can_access_closed: bool = None
     is_closed: bool = None
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
 
 class User(UserMin):
     sex: "base.Sex" = None

--- a/vkbottle/types/objects/utils.py
+++ b/vkbottle/types/objects/utils.py
@@ -7,6 +7,12 @@ class DomainResolved(BaseModel):
     object_id: int = None
     type: "DomainResolvedType" = None
 
+    def __hash__(self):
+        return hash((self.object_id, self.type))
+
+    def __eq__(self, other):
+        return self.object_id == other.object_id and self.type == other.type
+
 
 class DomainResolvedType(Enum):
     user = "user"

--- a/vkbottle/types/objects/video.py
+++ b/vkbottle/types/objects/video.py
@@ -39,6 +39,12 @@ class Video(BaseModel):
     views: int = None
     width: int = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class VideoAlbumFull(BaseModel):
     count: int = None
@@ -48,6 +54,12 @@ class VideoAlbumFull(BaseModel):
     owner_id: int = None
     title: str = None
     updated_time: int = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class VideoFiles(BaseModel):
@@ -85,6 +97,12 @@ class VideoFull(BaseModel):
     repeat: "base.BoolInt" = None
     title: str = None
     views: int = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class VideoImage(base.Image):

--- a/vkbottle/types/objects/wall.py
+++ b/vkbottle/types/objects/wall.py
@@ -32,6 +32,12 @@ class AttachedNote(BaseModel):
     title: str = None
     view_url: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class CommentAttachment(BaseModel):
     audio: "audio.Audio" = None
@@ -73,6 +79,12 @@ class Graffiti(BaseModel):
     photo_200: str = None
     photo_586: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class PostSource(BaseModel):
     data: str = None
@@ -103,6 +115,12 @@ class PostedPhoto(BaseModel):
     photo_130: str = None
     photo_604: str = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class Views(BaseModel):
     count: int = None
@@ -124,6 +142,12 @@ class WallComment(BaseModel):
     parents_stack: typing.List = None
     deleted: bool = None
 
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
+
 
 class Wallpost(BaseModel):
     access_key: str = None
@@ -143,6 +167,12 @@ class Wallpost(BaseModel):
     signer_id: int = None
     text: str = None
     views: "Views" = None
+
+    def __hash__(self):
+        return hash((self.owner_id, self.id))
+
+    def __eq__(self, other):
+        return self.owner_id == other.owner_id and self.id == other.id
 
 
 class WallpostAttachment(BaseModel):


### PR DESCRIPTION
**Что сделано:**
- Там, где это возможно в моделях добавлены методы __hash__ и __eq__

**Зачем это нужно?**

**- Для удобных, красивых и понятных сравнений!**
  Например, возьмём два раза последний пост в популярном сообществе:
  ```
  post = (await bot.api.wall.get(owner_id=-1, count=1)).items[0]
  await sleep(60)
  same_post = (await bot.api.wall.get(owner_id=-1, count=1)).items[0]
  ```
  Получая его в разное время, модели из-за счётчиков скорее всего будет разнится, а это уже значит что:
  `post == same_post  # False`
  Хотя пост один и тот же.
  
  Безусловно, можно сравнивать через .id и .owner_id:
  `post.id == same_post.id and post.owner_id == same_post.owner_id  # True`
  Но, это уже значительно усложняет код и его читаемость.

**- Для хэшируемости**
  Представим словарь последних постов сообществ
  ```
  last_posts: Dict[Group, Wallpost] = dict()
  group = (await bot.api.groups.get_by_id(group_id=1))[0]
  last_post = (await bot.api.wall.get(owner_id=-1, count=1)).items[0]
  ```
  И попробуем добавить наши модели:
  `last_posts[group] = last_post`
  На что получим ошибку `TypeError: unhashable type: 'GroupFull'`!
  Мои же изменения эту проблему решают.
