### PR TITLE
Фикс ModuleNotFoundError: No module named 'vbml'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import setuptools
 
-from vkbottle import const
-
 try:
     with open("README.md", "r", encoding="utf-8") as f:
         long_description = f.read()
@@ -13,7 +11,7 @@ except FileNotFoundError:
 
 setuptools.setup(
     name="vkbottle",
-    version=const.__version__,
+    version="2.7.7",
     author="timoniq",
     description="Homogenic!",
     long_description=long_description,


### PR DESCRIPTION
В момент отсутствия модуля `vbml`, при установке `vkbottle` выскакивала ошибка:
`Traceback (most recent call last):`
`from vkbottle import const`
` File "/tmp/pip-req-build-7icx97p2/vkbottle/__init__.py", line 1, in <module>`
`from .framework import Bot, User`
`File "/tmp/pip-req-build-7icx97p2/vkbottle/framework/__init__.py", line 1, in <module>`
`from .bot import Bot`
`File "/tmp/pip-req-build-7icx97p2/vkbottle/framework/bot/__init__.py", line 1, in <module>`
`from .bot import Bot`
`File "/tmp/pip-req-build-7icx97p2/vkbottle/framework/bot/bot.py", line 4, in <module>`
`from vbml import Patcher`
`ModuleNotFoundError: No module named 'vbml'`
Пробовал заменить на `import vkbottle.const as const`, но та же проблема.