### PR TITLE
Фикс StickerRule. Добавление ForwardMessagesRule и ReplyMessageRule

### DIFF
--- a/vkbottle/dispatch/rules/bot.py
+++ b/vkbottle/dispatch/rules/bot.py
@@ -101,7 +101,7 @@ class StickerRule(ABCMessageRule):
         elif not message.attachments[0].sticker:
             return False
         else:
-            if self.sticker_ids is None:
+            if not self.sticker_ids:
                 if message.attachments[0].sticker.sticker_id:
                     return True
             elif message.attachments[0].sticker.sticker_id in self.sticker_ids:
@@ -133,6 +133,22 @@ class AttachmentTypeRule(ABCMessageRule):
             if attachment.type.value not in self.attachment_types:
                 return False
         return True
+
+
+class ForwardMessagesRule(ABCMessageRule):
+    async def check(self, message: Message) -> bool:
+        if message.fwd_messages:
+            return True
+
+        return False
+
+
+class ReplyMessageRule(ABCMessageRule):
+    async def check(self, message: Message) -> bool:
+        if message.reply_message:
+            return True
+
+        return False
 
 
 class LevensteinRule(ABCMessageRule):

--- a/vkbottle/dispatch/rules/bot.py
+++ b/vkbottle/dispatch/rules/bot.py
@@ -137,18 +137,26 @@ class AttachmentTypeRule(ABCMessageRule):
 
 class ForwardMessagesRule(ABCMessageRule):
     async def check(self, message: Message) -> bool:
-        if message.fwd_messages:
-            return True
+        if not message.fwd_messages:
+            return False
 
-        return False
+        return True
 
 
 class ReplyMessageRule(ABCMessageRule):
     async def check(self, message: Message) -> bool:
-        if message.reply_message:
-            return True
+        if not message.reply_message:
+            return False
 
-        return False
+        return True
+
+
+class GeoRule(ABCMessageRule):
+    async def check(self, message: Message) -> bool:
+        if not message.geo:
+            return False
+
+        return True
 
 
 class LevensteinRule(ABCMessageRule):


### PR DESCRIPTION
StickerRule не срабатывал, так как когда создается рул `sticker_ids = sticker_ids or []` равен [], а [] не равен None.
Добавил новые рулы для ответа на сообщение, и пересланные сообщения.