### PR TITLE
Fix typing in ctx_storage.py

### DIFF
--- a/vkbottle/tools/dev_tools/storage/abc.py
+++ b/vkbottle/tools/dev_tools/storage/abc.py
@@ -8,19 +8,19 @@ class ABCStorage(ABC):
     """
 
     @abstractmethod
-    def get(self, key: str) -> typing.Any:
+    def get(self, key: typing.Hashable) -> typing.Any:
         pass
 
     @abstractmethod
-    def set(self, key: str, value: typing.Any) -> None:
+    def set(self, key: typing.Hashable, value: typing.Any) -> None:
         pass
 
     @abstractmethod
-    def delete(self, key: str) -> None:
+    def delete(self, key: typing.Hashable) -> None:
         pass
 
     @abstractmethod
-    def contains(self, key: str) -> bool:
+    def contains(self, key: typing.Hashable) -> bool:
         pass
 
     def __repr__(self):
@@ -29,8 +29,8 @@ class ABCStorage(ABC):
     def __contains__(self, item: str) -> bool:
         return self.contains(item)
 
-    def __setitem__(self, key: str, value: typing.Any) -> None:
+    def __setitem__(self, key: typing.Hashable, value: typing.Any) -> None:
         self.set(key, value)
 
-    def __getitem__(self, item: str) -> typing.Any:
-        return self.get(item)
+    def __getitem__(self, key: typing.Hashable) -> typing.Any:
+        return self.get(key)

--- a/vkbottle/tools/dev_tools/storage/ctx_storage.py
+++ b/vkbottle/tools/dev_tools/storage/ctx_storage.py
@@ -1,4 +1,5 @@
 import typing
+from typing import Optional
 
 from vkbottle.tools.dev_tools.ctx_tool import BaseContext
 
@@ -21,18 +22,18 @@ class CtxStorage(ABCStorage, BaseContext):
             self.storage = default
             self.set_instance(self)
 
-    def set(self, key: str, value: typing.Any) -> None:
+    def set(self, key: Optional[str, int, tuple], value: typing.Any) -> None:
         current_storage = self.get_instance().storage
         current_storage[key] = value
         self.set_instance(CtxStorage(current_storage, True))
 
-    def get(self, key: str) -> typing.Any:
+    def get(self, key: Optional[str, int, tuple]) -> typing.Any:
         return self.get_instance().storage.get(key)
 
-    def delete(self, key: str) -> None:
+    def delete(self, key: Optional[str, int, tuple]) -> None:
         new_storage = self.get_instance().storage
         new_storage.pop(key)
         self.set_instance(CtxStorage(new_storage, True))
 
-    def contains(self, key: str) -> bool:
+    def contains(self, key: Optional[str, int, tuple]) -> bool:
         return key in self.get_instance().storage

--- a/vkbottle/tools/dev_tools/storage/ctx_storage.py
+++ b/vkbottle/tools/dev_tools/storage/ctx_storage.py
@@ -1,5 +1,4 @@
 import typing
-from typing import Hashable
 
 from vkbottle.tools.dev_tools.ctx_tool import BaseContext
 
@@ -22,18 +21,18 @@ class CtxStorage(ABCStorage, BaseContext):
             self.storage = default
             self.set_instance(self)
 
-    def set(self, key: Hashable, value: typing.Any) -> None:
+    def set(self, key: typing.Hashable, value: typing.Any) -> None:
         current_storage = self.get_instance().storage
         current_storage[key] = value
         self.set_instance(CtxStorage(current_storage, True))
 
-    def get(self, key: Hashable) -> typing.Any:
+    def get(self, key: typing.Hashable) -> typing.Any:
         return self.get_instance().storage.get(key)
 
-    def delete(self, key: Hashable) -> None:
+    def delete(self, key: typing.Hashable) -> None:
         new_storage = self.get_instance().storage
         new_storage.pop(key)
         self.set_instance(CtxStorage(new_storage, True))
 
-    def contains(self, key: Hashable) -> bool:
+    def contains(self, key: typing.Hashable) -> bool:
         return key in self.get_instance().storage

--- a/vkbottle/tools/dev_tools/storage/ctx_storage.py
+++ b/vkbottle/tools/dev_tools/storage/ctx_storage.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional
+from typing import Hashable
 
 from vkbottle.tools.dev_tools.ctx_tool import BaseContext
 
@@ -22,18 +22,18 @@ class CtxStorage(ABCStorage, BaseContext):
             self.storage = default
             self.set_instance(self)
 
-    def set(self, key: Optional[str, int, tuple], value: typing.Any) -> None:
+    def set(self, key: Hashable, value: typing.Any) -> None:
         current_storage = self.get_instance().storage
         current_storage[key] = value
         self.set_instance(CtxStorage(current_storage, True))
 
-    def get(self, key: Optional[str, int, tuple]) -> typing.Any:
+    def get(self, key: Hashable) -> typing.Any:
         return self.get_instance().storage.get(key)
 
-    def delete(self, key: Optional[str, int, tuple]) -> None:
+    def delete(self, key: Hashable) -> None:
         new_storage = self.get_instance().storage
         new_storage.pop(key)
         self.set_instance(CtxStorage(new_storage, True))
 
-    def contains(self, key: Optional[str, int, tuple]) -> bool:
+    def contains(self, key: Hashable) -> bool:
         return key in self.get_instance().storage


### PR DESCRIPTION
В файле `examples/high-level/middleware_example.py` на строке 20 и 22 в PyCharm'e светились желтым, говорило это о том что функция ожидает str а дают ему int... Ну я как перфекционист(хорошая шутка) исправил это