### PR TITLE
Use "force-exclude" instead of "exclude"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pre-commit = "^2.12.0"
 [tool.black]
 line-length = 99
 target-version = ['py37', 'py38']
-exclude = '''
+force-exclude = '''
 (
     \.eggs
   | \.git


### PR DESCRIPTION
Какую проблему решает ваш PR: https://github.com/psf/black/issues/438
Если не хочешь, что бы исключенные в конфиге файлы форматировались при передаче их пути (например, при использовании `pre-commit`), то используй "force-exclude".
Фича доступна в  `black>=20.8b1`
