### PR TITLE
Added `message.reply` and `message.forward`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ python = "^3.7"
 aiohttp = "^3.6.2"
 vbml = "^1.0"
 choicelib = "^0.1.1"
-vkbottle-types = "0.1.24"
+vkbottle-types = "^5.131"
 watchgod = "^0.7"
 pydantic = "^1.8.2"
 

--- a/vkbottle/tools/dev/mini_types/bot/message.py
+++ b/vkbottle/tools/dev/mini_types/bot/message.py
@@ -2,14 +2,14 @@ from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
 from vkbottle_types.events.bot_events import MessageNew
-from vkbottle_types.objects import MessagesClientInfo, MessagesForward, MessagesMessage, UsersUser
+from vkbottle_types.objects import ClientInfoForBots, MessagesForward, MessagesMessage, UsersUser
 
 from vkbottle.api import ABCAPI, API
 
 
 class MessageMin(MessagesMessage):
     group_id: Optional[int] = None
-    client_info: Optional["MessagesClientInfo"] = None
+    client_info: Optional["ClientInfoForBots"] = None
     unprepared_ctx_api: Optional[Any] = None
     state_peer: Optional[StatePeer] = None
 
@@ -58,24 +58,6 @@ class MessageMin(MessagesMessage):
         self,
         message: Optional[str] = None,
         attachment: Optional[str] = None,
-        user_id: Optional[int] = None,
-        domain: Optional[str] = None,
-        chat_id: Optional[int] = None,
-        random_id: Optional[int] = 0,
-        user_ids: Optional[List[int]] = None,
-        lat: Optional[float] = None,
-        long: Optional[float] = None,
-        reply_to: Optional[int] = None,
-        forward_messages: Optional[List[int]] = None,
-        forward: Optional[str] = None,
-        sticker_id: Optional[int] = None,
-        group_id: Optional[int] = None,
-        keyboard: Optional[str] = None,
-        payload: Optional[str] = None,
-        dont_parse_links: Optional[bool] = None,
-        disable_mentions: Optional[bool] = None,
-        template: Optional[str] = None,
-        intent: Optional[str] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
@@ -85,34 +67,16 @@ class MessageMin(MessagesMessage):
         data["forward"] = MessagesForward(
             conversation_message_ids=[self.conversation_message_id],
             peer_id=self.peer_id,
-            is_reply=True
+            is_reply=True,
         ).json()
 
-        return (await self.ctx_api.request("messages.send", data))["response"]
+        return await self.answer(**data)
 
     async def forward(
         self,
         message: Optional[str] = None,
         attachment: Optional[str] = None,
-        peer_id: Optional[int] = None,
-        user_id: Optional[int] = None,
-        domain: Optional[str] = None,
-        chat_id: Optional[int] = None,
-        random_id: Optional[int] = 0,
-        user_ids: Optional[List[int]] = None,
-        lat: Optional[float] = None,
-        long: Optional[float] = None,
-        reply_to: Optional[int] = None,
-        forward_messages: Optional[List[int]] = None,
-        forward: Optional[str] = None,
-        sticker_id: Optional[int] = None,
-        group_id: Optional[int] = None,
-        keyboard: Optional[str] = None,
-        payload: Optional[str] = None,
-        dont_parse_links: Optional[bool] = None,
-        disable_mentions: Optional[bool] = None,
-        template: Optional[str] = None,
-        intent: Optional[str] = None,
+        forward_message_ids: Optional[List[int]] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
@@ -121,12 +85,15 @@ class MessageMin(MessagesMessage):
         required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
         if not any(data.get(param) for param in required_params):
             data["peer_id"] = self.peer_id
+        if not forward_message_ids:
+            forward_message_ids = [self.conversation_message_id]
+
         data["forward"] = MessagesForward(
-            conversation_message_ids=[self.conversation_message_id],
-            peer_id=self.peer_id
+            conversation_message_ids=forward_message_ids, peer_id=self.peer_id
         ).json()
 
-        return (await self.ctx_api.request("messages.send", data))["response"]
+        return await self.answer(**data)
+
 
 MessageMin.update_forward_refs()
 

--- a/vkbottle/tools/dev/mini_types/bot/message.py
+++ b/vkbottle/tools/dev/mini_types/bot/message.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
 from vkbottle_types.events.bot_events import MessageNew
-from vkbottle_types.objects import MessagesClientInfo, MessagesMessage, UsersUser
+from vkbottle_types.objects import ClientInfoForBots, MessagesForward, MessagesMessage, UsersUser
 
 from vkbottle.api import ABCAPI, API
 
@@ -54,6 +54,73 @@ class MessageMin(MessagesMessage):
 
         return (await self.ctx_api.request("messages.send", data))["response"]
 
+    async def reply(
+        self,
+        message: Optional[str] = None,
+        attachment: Optional[str] = None,
+        user_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        user_ids: Optional[List[int]] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        reply_to: Optional[int] = None,
+        forward_messages: Optional[List[int]] = None,
+        forward: Optional[str] = None,
+        sticker_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        keyboard: Optional[str] = None,
+        payload: Optional[str] = None,
+        dont_parse_links: Optional[bool] = None,
+        disable_mentions: Optional[bool] = None,
+        **kwargs,
+    ) -> int:
+        locals().update(kwargs)
+        locals().pop("kwargs")
+        data = {k: v for k, v in locals().items() if k != "self" and v is not None}
+        data["peer_id"] = self.peer_id
+        data["forward"] = MessagesForward(
+            conversation_message_ids=[self.conversation_message_id],
+            peer_id=self.peer_id,
+            is_reply=True
+        ).json()
+
+        return (await self.ctx_api.request("messages.send", data))["response"]
+
+    async def forward(
+        self,
+        message: Optional[str] = None,
+        attachment: Optional[str] = None,
+        peer_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        user_ids: Optional[List[int]] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        reply_to: Optional[int] = None,
+        forward_messages: Optional[List[int]] = None,
+        forward: Optional[str] = None,
+        sticker_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        keyboard: Optional[str] = None,
+        payload: Optional[str] = None,
+        dont_parse_links: Optional[bool] = None,
+        disable_mentions: Optional[bool] = None,
+        **kwargs,
+    ) -> int:
+        locals().update(kwargs)
+        locals().pop("kwargs")
+        data = {k: v for k, v in locals().items() if k != "self" and v is not None}
+        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
+        if not any(data.get(param) for param in required_params):
+            data["peer_id"] = self.peer_id
+        data["forward"] = MessagesForward(
+            conversation_message_ids=[self.conversation_message_id],
+            peer_id=self.peer_id
+        ).json()
+
+        return (await self.ctx_api.request("messages.send", data))["response"]
 
 MessageMin.update_forward_refs()
 

--- a/vkbottle/tools/dev/mini_types/bot/message.py
+++ b/vkbottle/tools/dev/mini_types/bot/message.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
 from vkbottle_types.events.bot_events import MessageNew
-from vkbottle_types.objects import ClientInfoForBots, MessagesForward, MessagesMessage, UsersUser
+from vkbottle_types.objects import MessagesClientInfo, MessagesForward, MessagesMessage, UsersUser
 
 from vkbottle.api import ABCAPI, API
 
@@ -61,6 +61,7 @@ class MessageMin(MessagesMessage):
         user_id: Optional[int] = None,
         domain: Optional[str] = None,
         chat_id: Optional[int] = None,
+        random_id: Optional[int] = 0,
         user_ids: Optional[List[int]] = None,
         lat: Optional[float] = None,
         long: Optional[float] = None,
@@ -73,11 +74,13 @@ class MessageMin(MessagesMessage):
         payload: Optional[str] = None,
         dont_parse_links: Optional[bool] = None,
         disable_mentions: Optional[bool] = None,
+        template: Optional[str] = None,
+        intent: Optional[str] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
-        locals().pop("kwargs")
-        data = {k: v for k, v in locals().items() if k != "self" and v is not None}
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
         data["peer_id"] = self.peer_id
         data["forward"] = MessagesForward(
             conversation_message_ids=[self.conversation_message_id],
@@ -95,6 +98,7 @@ class MessageMin(MessagesMessage):
         user_id: Optional[int] = None,
         domain: Optional[str] = None,
         chat_id: Optional[int] = None,
+        random_id: Optional[int] = 0,
         user_ids: Optional[List[int]] = None,
         lat: Optional[float] = None,
         long: Optional[float] = None,
@@ -107,11 +111,13 @@ class MessageMin(MessagesMessage):
         payload: Optional[str] = None,
         dont_parse_links: Optional[bool] = None,
         disable_mentions: Optional[bool] = None,
+        template: Optional[str] = None,
+        intent: Optional[str] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
-        locals().pop("kwargs")
-        data = {k: v for k, v in locals().items() if k != "self" and v is not None}
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
         required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
         if not any(data.get(param) for param in required_params):
             data["peer_id"] = self.peer_id

--- a/vkbottle/tools/dev/mini_types/bot/message.py
+++ b/vkbottle/tools/dev/mini_types/bot/message.py
@@ -28,9 +28,11 @@ class MessageMin(MessagesMessage):
         message: Optional[str] = None,
         attachment: Optional[str] = None,
         user_id: Optional[int] = None,
+        random_id: Optional[int] = 0,
+        peer_id: Optional[int] = None,
+        peer_ids: Optional[List[int]] = None,
         domain: Optional[str] = None,
         chat_id: Optional[int] = None,
-        random_id: Optional[int] = 0,
         user_ids: Optional[List[int]] = None,
         lat: Optional[float] = None,
         long: Optional[float] = None,
@@ -40,17 +42,21 @@ class MessageMin(MessagesMessage):
         sticker_id: Optional[int] = None,
         group_id: Optional[int] = None,
         keyboard: Optional[str] = None,
+        template: Optional[str] = None,
         payload: Optional[str] = None,
+        content_source: Optional[str] = None,
         dont_parse_links: Optional[bool] = None,
         disable_mentions: Optional[bool] = None,
-        template: Optional[str] = None,
         intent: Optional[str] = None,
+        subscribe_id: Optional[int] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
 
         data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        data["peer_id"] = self.peer_id
+        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
+        if not any(data.get(param) for param in required_params):
+            data["peer_id"] = self.peer_id
 
         return (await self.ctx_api.request("messages.send", data))["response"]
 
@@ -81,13 +87,13 @@ class MessageMin(MessagesMessage):
     ) -> int:
         locals().update(kwargs)
 
-        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
-        if not any(data.get(param) for param in required_params):
-            data["peer_id"] = self.peer_id
+        data = {
+            k: v
+            for k, v in locals().items()
+            if k not in ("self", "kwargs", "forward_message_ids") and v is not None
+        }
         if not forward_message_ids:
             forward_message_ids = [self.conversation_message_id]
-
         data["forward"] = MessagesForward(
             conversation_message_ids=forward_message_ids, peer_id=self.peer_id
         ).json()

--- a/vkbottle/tools/dev/mini_types/user/message.py
+++ b/vkbottle/tools/dev/mini_types/user/message.py
@@ -2,7 +2,7 @@ from random import randint
 from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
-from vkbottle_types.objects import MessagesForward, MessagesMessage, UsersUser
+from vkbottle_types.objects import MessagesMessage, UsersUser
 
 from vkbottle.api import ABCAPI, API
 
@@ -55,70 +55,36 @@ class MessageMin(MessagesMessage):
         self,
         message: Optional[str] = None,
         attachment: Optional[str] = None,
-        user_id: Optional[int] = None,
-        domain: Optional[str] = None,
-        chat_id: Optional[int] = None,
-        user_ids: Optional[List[int]] = None,
-        lat: Optional[float] = None,
-        long: Optional[float] = None,
-        reply_to: Optional[int] = None,
-        forward_messages: Optional[List[int]] = None,
-        forward: Optional[str] = None,
-        sticker_id: Optional[int] = None,
-        group_id: Optional[int] = None,
-        keyboard: Optional[str] = None,
-        payload: Optional[str] = None,
-        dont_parse_links: Optional[bool] = None,
-        disable_mentions: Optional[bool] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
 
         data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        data["random_id"] = randint(-2000000000, 2000000000)
         data["peer_id"] = self.peer_id
-        data["forward"] = MessagesForward(
-            conversation_message_ids=[self.conversation_message_id],
-            peer_id=self.peer_id,
-            is_reply=True
-        ).json()
+        data["reply_to"] = self.id
 
-        return (await self.ctx_api.request("messages.send", data))["response"]
+        return await self.answer(**data)
 
     async def forward(
         self,
         message: Optional[str] = None,
         attachment: Optional[str] = None,
-        peer_id: Optional[int] = None,
-        user_id: Optional[int] = None,
-        domain: Optional[str] = None,
-        chat_id: Optional[int] = None,
-        user_ids: Optional[List[int]] = None,
-        lat: Optional[float] = None,
-        long: Optional[float] = None,
-        reply_to: Optional[int] = None,
-        forward_messages: Optional[List[int]] = None,
-        forward: Optional[str] = None,
-        sticker_id: Optional[int] = None,
-        group_id: Optional[int] = None,
-        keyboard: Optional[str] = None,
-        payload: Optional[str] = None,
-        dont_parse_links: Optional[bool] = None,
-        disable_mentions: Optional[bool] = None,
+        forward_message_ids: Optional[List[int]] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
 
         data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        data["random_id"] = randint(-2000000000, 2000000000)
-        if not any(data.get(param) for param in ("peer_id", "user_id", "domain", "chat_id", "user_ids")):
+        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
+        if not any(data.get(param) for param in required_params):
             data["peer_id"] = self.peer_id
-        data["forward"] = MessagesForward(
-            conversation_message_ids=[self.conversation_message_id],
-            peer_id=self.peer_id
-        ).json()
+        if not forward_message_ids:
+            forward_message_ids = [self.id]
 
-        return (await self.ctx_api.request("messages.send", data))["response"]
+        data["forward_messages"] = forward_message_ids
+
+        return await self.answer(**data)
+
 
 MessageMin.update_forward_refs()
 

--- a/vkbottle/tools/dev/mini_types/user/message.py
+++ b/vkbottle/tools/dev/mini_types/user/message.py
@@ -2,7 +2,7 @@ from random import randint
 from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
-from vkbottle_types.objects import MessagesMessage, UsersUser
+from vkbottle_types.objects import MessagesForward, MessagesMessage, UsersUser
 
 from vkbottle.api import ABCAPI, API
 
@@ -44,13 +44,81 @@ class MessageMin(MessagesMessage):
         **kwargs,
     ) -> int:
         locals().update(kwargs)
-        locals().pop("kwargs")
-        data = {k: v for k, v in locals().items() if k != "self" and v is not None}
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
         data["random_id"] = randint(-2000000000, 2000000000)
         data["peer_id"] = self.peer_id
 
         return (await self.ctx_api.request("messages.send", data))["response"]
 
+    async def reply(
+        self,
+        message: Optional[str] = None,
+        attachment: Optional[str] = None,
+        user_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        user_ids: Optional[List[int]] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        reply_to: Optional[int] = None,
+        forward_messages: Optional[List[int]] = None,
+        forward: Optional[str] = None,
+        sticker_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        keyboard: Optional[str] = None,
+        payload: Optional[str] = None,
+        dont_parse_links: Optional[bool] = None,
+        disable_mentions: Optional[bool] = None,
+        **kwargs,
+    ) -> int:
+        locals().update(kwargs)
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
+        data["random_id"] = randint(-2000000000, 2000000000)
+        data["peer_id"] = self.peer_id
+        data["forward"] = MessagesForward(
+            conversation_message_ids=[self.conversation_message_id],
+            peer_id=self.peer_id,
+            is_reply=True
+        ).json()
+
+        return (await self.ctx_api.request("messages.send", data))["response"]
+
+    async def forward(
+        self,
+        message: Optional[str] = None,
+        attachment: Optional[str] = None,
+        peer_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        user_ids: Optional[List[int]] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        reply_to: Optional[int] = None,
+        forward_messages: Optional[List[int]] = None,
+        forward: Optional[str] = None,
+        sticker_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        keyboard: Optional[str] = None,
+        payload: Optional[str] = None,
+        dont_parse_links: Optional[bool] = None,
+        disable_mentions: Optional[bool] = None,
+        **kwargs,
+    ) -> int:
+        locals().update(kwargs)
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
+        data["random_id"] = randint(-2000000000, 2000000000)
+        if not any(data.get(param) for param in ("peer_id", "user_id", "domain", "chat_id", "user_ids")):
+            data["peer_id"] = self.peer_id
+        data["forward"] = MessagesForward(
+            conversation_message_ids=[self.conversation_message_id],
+            peer_id=self.peer_id
+        ).json()
+
+        return (await self.ctx_api.request("messages.send", data))["response"]
 
 MessageMin.update_forward_refs()
 

--- a/vkbottle/tools/dev/mini_types/user/message.py
+++ b/vkbottle/tools/dev/mini_types/user/message.py
@@ -1,4 +1,3 @@
-from random import randint
 from typing import Any, List, Optional, Union
 
 from vkbottle_types import StatePeer
@@ -27,6 +26,9 @@ class MessageMin(MessagesMessage):
         message: Optional[str] = None,
         attachment: Optional[str] = None,
         user_id: Optional[int] = None,
+        random_id: Optional[int] = 0,
+        peer_id: Optional[int] = None,
+        peer_ids: Optional[List[int]] = None,
         domain: Optional[str] = None,
         chat_id: Optional[int] = None,
         user_ids: Optional[List[int]] = None,
@@ -38,15 +40,18 @@ class MessageMin(MessagesMessage):
         sticker_id: Optional[int] = None,
         group_id: Optional[int] = None,
         keyboard: Optional[str] = None,
+        template: Optional[str] = None,
         payload: Optional[str] = None,
+        content_source: Optional[str] = None,
         dont_parse_links: Optional[bool] = None,
         disable_mentions: Optional[bool] = None,
+        intent: Optional[str] = None,
+        subscribe_id: Optional[int] = None,
         **kwargs,
     ) -> int:
         locals().update(kwargs)
 
         data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        data["random_id"] = randint(-2000000000, 2000000000)
         data["peer_id"] = self.peer_id
 
         return (await self.ctx_api.request("messages.send", data))["response"]
@@ -74,10 +79,11 @@ class MessageMin(MessagesMessage):
     ) -> int:
         locals().update(kwargs)
 
-        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
-        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
-        if not any(data.get(param) for param in required_params):
-            data["peer_id"] = self.peer_id
+        data = {
+            k: v
+            for k, v in locals().items()
+            if k not in ("self", "kwargs", "forward_message_ids") and v is not None
+        }
         if not forward_message_ids:
             forward_message_ids = [self.id]
 


### PR DESCRIPTION
Какую проблему решает ваш PR:  Возможность переслать и сделать ответ на сообщение
Ответ на сообщение через `message.reply(...)` и пересылка сообщения через `message.forward(...)` (не только в текущий чат, но и с возможностью указать место назначения)
Можно было сделать все отправки сообщений через message.answer, но мне этот вариант не очень понравился. Если будет нужно, то можете подкорректировать этот момент
Пример использования:
```
@bp.on.message(text="Привет")
async def greeting(message: Message):
    await message.reply("Hi! (reply)")
    await message.forward("Привет! (forward)")
    await message.forward("Павел, смотри, что он написал мне:", peer_id=1)
```
