### PR TITLE
Add `state_dispenser` param for Bot

### DIFF
--- a/vkbottle/framework/bot/bot.py
+++ b/vkbottle/framework/bot/bot.py
@@ -3,6 +3,7 @@ from typing import NoReturn, Optional, Union
 
 from vkbottle.api import ABCAPI, API, Token
 from vkbottle.dispatch import ABCRouter, BotRouter, BuiltinStateDispenser
+from vkbottle.dispatch import ABCStateDispenser
 from vkbottle.exception_factory import ABCErrorHandler, ErrorHandler
 from vkbottle.framework.abc import ABCFramework
 from vkbottle.modules import logger
@@ -22,6 +23,7 @@ class Bot(ABCFramework):
         loop_wrapper: Optional[LoopWrapper] = None,
         router: Optional["ABCRouter"] = None,
         labeler: Optional["ABCBotLabeler"] = None,
+        state_dispenser: Optional["ABCStateDispenser"] = None,
         error_handler: Optional["ABCErrorHandler"] = None,
         task_each_event: bool = True,
     ):
@@ -29,7 +31,7 @@ class Bot(ABCFramework):
         self.error_handler = error_handler or ErrorHandler()
         self.loop_wrapper = loop_wrapper or LoopWrapper()
         self.labeler = labeler or BotLabeler()
-        self.state_dispenser = BuiltinStateDispenser()
+        self.state_dispenser = state_dispenser or BuiltinStateDispenser()
         self._polling = polling or BotPolling(self.api)
         self._router = router or BotRouter()
         self._loop = loop


### PR DESCRIPTION
Какую проблему решает ваш PR:
При создании бота нельзя задать свой StateDispenser

* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
