### PR TITLE
Add supporting of MessageEvent by dataclass

### DIFF
--- a/docs/tools/message-event.md
+++ b/docs/tools/message-event.md
@@ -1,0 +1,17 @@
+# MessageEvent
+
+Обработка `callback` кнопок выходит на новый уровень:
+
+```python
+from vkbottle import GroupEventType
+from vkbottle.bot import MessageEvent
+
+@bot.on.raw_event(GroupEventType.MESSAGE_EVENT, dataclass=MessageEvent)
+async def handle_message_event(event: MessageEvent):
+    await event.show_snackbar("Сейчас я исчезну")
+```
+
+* Никакого `object`. Всё находится уже в `event`, вместе с `group_id`
+* Поддержка всех генераторов `event-data` при помощи соответствующими функциями
+* Поддержка рулзов, связанных с `payload`
+* Так же есть `message_edit` и `message_send`

--- a/examples/high-level/message_event.py
+++ b/examples/high-level/message_event.py
@@ -1,5 +1,5 @@
 # Example of sending and receiving an event after pressing the Callback button
-# Documentation: https://vk.cc/aC9JG2
+# Documentation: https://vk.com/dev/bots_docs_5?f=4.4.%20Callback-кнопки
 
 import logging
 import os
@@ -27,18 +27,28 @@ async def send_callback_button(message: Message):
 
 
 @bot.on.raw_event(
-    GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "snackbar"})
+    rules.PayloadRule({"cmd": "snackbar"}),
+    event=GroupEventType.MESSAGE_EVENT,
+    dataclass=MessageEvent,
 )
 async def show_snackbar(event: MessageEvent):
     await event.show_snackbar("Сейчас я исчезну")
 
 
-@bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "app"}))
+@bot.on.raw_event(
+    rules.PayloadRule({"cmd": "app"}),
+    event=GroupEventType.MESSAGE_EVENT,
+    dataclass=MessageEvent,
+)
 async def open_app(event: MessageEvent):
     await event.open_app(6798836, "reg", event.user_id)
 
 
-@bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "close"}))
+@bot.on.raw_event(
+    rules.PayloadRule({"cmd": "close"}),
+    event=GroupEventType.MESSAGE_EVENT,
+    dataclass=MessageEvent,
+)
 async def edit_message(event: MessageEvent):
     await event.edit_message("Окей")
 

--- a/examples/high-level/message_event.py
+++ b/examples/high-level/message_event.py
@@ -29,17 +29,17 @@ async def send_callback_button(message: Message):
 @bot.on.raw_event(
     GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "snackbar"})
 )
-async def handle_message_event(event: MessageEvent):
+async def show_snackbar(event: MessageEvent):
     await event.show_snackbar("Сейчас я исчезну")
 
 
 @bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "app"}))
-async def handle_message_event(event: MessageEvent):
+async def open_app(event: MessageEvent):
     await event.open_app(6798836, "reg", event.user_id)
 
 
 @bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "close"}))
-async def handle_message_event(event: MessageEvent):
+async def edit_message(event: MessageEvent):
     await event.edit_message("Окей")
 
 

--- a/examples/high-level/message_event.py
+++ b/examples/high-level/message_event.py
@@ -1,0 +1,46 @@
+# Example of sending and receiving an event after pressing the Callback button
+# Documentation: https://vk.cc/aC9JG2
+
+import logging
+import os
+
+from vkbottle import Callback, GroupEventType, Keyboard
+from vkbottle.bot import Bot, Message, MessageEvent, rules
+
+bot = Bot(os.environ["TOKEN"])
+logging.basicConfig(level=logging.INFO)
+
+KEYBOARD = (
+    Keyboard(one_time=False, inline=True)
+    .add(Callback("Показать текст", payload={"cmd": "snackbar"}))
+    .row()
+    .add(Callback("Дата регистрации (tool42)", payload={"cmd": "app"}))
+    .row()
+    .add(Callback("Закрыть", payload={"cmd": "close"}))
+    .get_json()
+)
+
+
+@bot.on.private_message(text="/callback")
+async def send_callback_button(message: Message):
+    await message.answer("Лови!", keyboard=KEYBOARD)
+
+
+@bot.on.raw_event(
+    GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "snackbar"})
+)
+async def handle_message_event(event: MessageEvent):
+    await event.show_snackbar("Сейчас я исчезну")
+
+
+@bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "app"}))
+async def handle_message_event(event: MessageEvent):
+    await event.open_app(6798836, "reg", event.user_id)
+
+
+@bot.on.raw_event(GroupEventType.MESSAGE_EVENT, MessageEvent, rules.PayloadRule({"cmd": "close"}))
+async def handle_message_event(event: MessageEvent):
+    await event.edit_message("Окей")
+
+
+bot.run_forever()

--- a/vkbottle/bot.py
+++ b/vkbottle/bot.py
@@ -1,9 +1,10 @@
 from .dispatch.rules import base as rules
 from .dispatch.views import bot as views
 from .framework.bot import ABCBotLabeler, Bot, BotBlueprint, BotLabeler, run_multibot
-from .tools.dev.mini_types.bot import MessageMin
+from .tools.dev.mini_types.bot import MessageEventMin, MessageMin
 
 Message = MessageMin
+MessageEvent = MessageEventMin
 Blueprint = BotBlueprint
 
 __all__ = (
@@ -12,6 +13,7 @@ __all__ = (
     "Blueprint",
     "BotLabeler",
     "Message",
+    "MessageEvent",
     "run_multibot",
     "rules",
     "views",

--- a/vkbottle/tools/dev/mini_types/__init__.py
+++ b/vkbottle/tools/dev/mini_types/__init__.py
@@ -3,6 +3,7 @@ from . import bot, user
 
 class BotTypes:
     Message = bot.MessageMin
+    MessageEvent = bot.MessageEventMin
 
 
 class UserTypes:

--- a/vkbottle/tools/dev/mini_types/bot/__init__.py
+++ b/vkbottle/tools/dev/mini_types/bot/__init__.py
@@ -1,3 +1,4 @@
 from .message import MessageMin, message_min
+from .message_event import MessageEventMin
 
-__all__ = ("message_min", "MessageMin")
+__all__ = ("message_min", "MessageMin", "MessageEventMin")

--- a/vkbottle/tools/dev/mini_types/bot/message_event.py
+++ b/vkbottle/tools/dev/mini_types/bot/message_event.py
@@ -1,19 +1,15 @@
 from io import StringIO
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from vkbottle_types.events import MessageEvent
 from vkbottle_types.events.objects.group_event_objects import MessageEventObject
-from vkbottle_types.objects import BaseBoolInt
 
 from vkbottle import StatePeer
-
-from ...event_data import OpenAppEvent, OpenLinkEvent, ShowSnackbarEvent
+from vkbottle.tools.dev.event_data import OpenAppEvent, OpenLinkEvent, ShowSnackbarEvent
 
 if TYPE_CHECKING:
-
     from vkbottle.api import ABCAPI, API
 
-EventDataType = Union[ShowSnackbarEvent, OpenAppEvent, OpenLinkEvent]
+    EventDataType = Union[ShowSnackbarEvent, OpenAppEvent, OpenLinkEvent]
 
 
 class MessageEventMin(MessageEventObject):
@@ -22,9 +18,8 @@ class MessageEventMin(MessageEventObject):
     group_id: Optional[int] = None
 
     def __init__(self, **event):
-        update = MessageEvent(**event)
-        data = update.object.dict()
-        data["group_id"] = update.group_id
+        data = event["object"]
+        data["group_id"] = event.group_id
 
         super().__init__(**data)
 
@@ -32,7 +27,7 @@ class MessageEventMin(MessageEventObject):
     def ctx_api(self) -> Union["ABCAPI", "API"]:
         return getattr(self, "unprepared_ctx_api")
 
-    async def send_message_event_answer(self, event_data: EventDataType, **kwargs) -> int:
+    async def send_message_event_answer(self, event_data: "EventDataType", **kwargs) -> int:
         data = dict(
             event_id=self.event_id,
             user_id=self.user_id,
@@ -65,7 +60,7 @@ class MessageEventMin(MessageEventObject):
         template: Optional[str] = None,
         keyboard: Optional[str] = None,
         **kwargs,
-    ) -> "BaseBoolInt":
+    ) -> int:
         locals().update(kwargs)
 
         data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}

--- a/vkbottle/tools/dev/mini_types/bot/message_event.py
+++ b/vkbottle/tools/dev/mini_types/bot/message_event.py
@@ -1,0 +1,122 @@
+from io import StringIO
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+from vkbottle_types.events import MessageEvent
+from vkbottle_types.events.objects.group_event_objects import MessageEventObject
+from vkbottle_types.objects import BaseBoolInt
+
+from vkbottle import StatePeer
+
+from ...event_data import OpenAppEvent, OpenLinkEvent, ShowSnackbarEvent
+
+if TYPE_CHECKING:
+
+    from vkbottle.api import ABCAPI, API
+
+EventDataType = Union[ShowSnackbarEvent, OpenAppEvent, OpenLinkEvent]
+
+
+class MessageEventMin(MessageEventObject):
+    unprepared_ctx_api: Optional[Any] = None
+    state_peer: Optional["StatePeer"] = None
+    group_id: Optional[int] = None
+
+    def __init__(self, **event):
+        update = MessageEvent(**event)
+        data = update.object.dict()
+        data["group_id"] = update.group_id
+
+        super().__init__(**data)
+
+    @property
+    def ctx_api(self) -> Union["ABCAPI", "API"]:
+        return getattr(self, "unprepared_ctx_api")
+
+    async def send_message_event_answer(self, event_data: EventDataType, **kwargs) -> int:
+        data = dict(
+            event_id=self.event_id,
+            user_id=self.user_id,
+            peer_id=self.peer_id,
+            event_data=event_data.json(),
+        )
+        data.update(kwargs)
+        return (await self.ctx_api.request("messages.sendMessageEventAnswer", data))["response"]
+
+    async def show_snackbar(self, text: str) -> int:
+        return await self.send_message_event_answer(ShowSnackbarEvent(text=text))
+
+    async def open_link(self, link: str) -> int:
+        return await self.send_message_event_answer(OpenLinkEvent(link=link))
+
+    async def open_app(self, app_id: int, app_hash: str, owner_id: Optional[int] = None) -> int:
+        return await self.send_message_event_answer(
+            OpenAppEvent(app_id=app_id, hash=app_hash, owner_id=owner_id)
+        )
+
+    async def edit_message(
+        self,
+        message: Optional[str] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        attachment: Optional[str] = None,
+        keep_forward_messages: Optional[bool] = None,
+        keep_snippets: Optional[bool] = None,
+        dont_parse_links: Optional[bool] = None,
+        template: Optional[str] = None,
+        keyboard: Optional[str] = None,
+        **kwargs,
+    ) -> "BaseBoolInt":
+        locals().update(kwargs)
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
+        data["peer_id"] = self.peer_id
+        data["conversation_message_id"] = self.conversation_message_id
+        return (await self.ctx_api.request("messages.edit", data))["response"]
+
+    async def send_message(
+        self,
+        message: Optional[str] = None,
+        attachment: Optional[str] = None,
+        user_id: Optional[int] = None,
+        random_id: Optional[int] = 0,
+        peer_id: Optional[int] = None,
+        peer_ids: Optional[List[int]] = None,
+        domain: Optional[str] = None,
+        chat_id: Optional[int] = None,
+        user_ids: Optional[List[int]] = None,
+        lat: Optional[float] = None,
+        long: Optional[float] = None,
+        reply_to: Optional[int] = None,
+        forward_messages: Optional[List[int]] = None,
+        forward: Optional[str] = None,
+        sticker_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        keyboard: Optional[str] = None,
+        template: Optional[str] = None,
+        payload: Optional[str] = None,
+        content_source: Optional[str] = None,
+        dont_parse_links: Optional[bool] = None,
+        disable_mentions: Optional[bool] = None,
+        intent: Optional[str] = None,
+        subscribe_id: Optional[int] = None,
+        **kwargs,
+    ) -> int:
+        locals().update(kwargs)
+
+        data = {k: v for k, v in locals().items() if k not in ("self", "kwargs") and v is not None}
+        required_params = ("peer_id", "user_id", "domain", "chat_id", "user_ids")
+        if not any(data.get(param) for param in required_params):
+            data["peer_id"] = self.peer_id
+
+        stream = StringIO(message)
+        while True:
+            msg = stream.read(4096)
+            if msg:
+                data["message"] = msg
+            response = (await self.ctx_api.request("messages.send", data))["response"]
+            if stream.tell() == len(message or ""):
+                break
+        return response
+
+
+MessageEventMin.update_forward_refs()

--- a/vkbottle/tools/dev/uploader/base.py
+++ b/vkbottle/tools/dev/uploader/base.py
@@ -3,7 +3,6 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from vkbottle.exception_factory.base_exceptions import VKAPIError
-
 from vkbottle.modules import json
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Какую проблему решает ваш PR: Добавляет поддержку message_event при помощи `dataclass` в `raw_event`. Превращает работу с Callback-кнопками похожим на работу с Message.

* [X] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [X] Для вашего кода есть примеры использования в examples.
