### PR TITLE
Add cycle attribute to ConsistentTokenGenerator

### DIFF
--- a/vkbottle/api/token_generator/consistent.py
+++ b/vkbottle/api/token_generator/consistent.py
@@ -6,7 +6,8 @@ from .abc import ABCTokenGenerator
 
 class ConsistentTokenGenerator(ABCTokenGenerator):
     def __init__(self, tokens: Iterable[str]):
-        self.tokens = itertools.cycle(tokens)
+        self.tokens = tokens
+        self.cycle = itertools.cycle(self.tokens)
 
     async def get_token(self) -> str:
-        return next(self.tokens)
+        return next(self.cycle)


### PR DESCRIPTION
Столкнулся с проблемой невозможности получить количество токенов в ConsistentTokenGenerator, данный PR исправляет эту проблему и разделяет аттрибуты на tokens и cycle, где в tokens - токены, а в cycle - итератор.