### PR TITLE
changed typing for event parameter

### DIFF
--- a/vkbottle/framework/labeler/user.py
+++ b/vkbottle/framework/labeler/user.py
@@ -65,7 +65,7 @@ class UserLabeler(BaseLabeler):
 
     def raw_event(
         self,
-        event: Union[str, List[str]],
+        event: Union[int, List[int], UserEventType, List[UserEventType]],
         dataclass: Type["BaseUserEvent"] = RawUserEvent,
         *rules: "ABCRule",
         blocking: bool = True,


### PR DESCRIPTION
Since user events accept integers as the keys, argument "event" should accept either integers or UserEventType not string

Какую проблему решает ваш PR: ...

Связанные issue: # .

* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
