### PR TITLE
Add workflow dependency caching

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 99
 ignore = F405, F403, W503, E501, E203
-exclude = .git, build, dist, venv, docs, examples, tests, *.egg-info
+exclude = .git, build, dist, venv, .venv, docs, examples, tests, *.egg-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v3.1.1
+        id: python-setup
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
+        if: steps.python-setup.outputs.cache-hit != 'true'
         run: poetry install
 
       - name: Run flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,24 @@ jobs:
           - 3.9
 
     steps:
-      - uses: dhvcc/python-poetry-setup@v1
+      - uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache-key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/poetry.lock') }}
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install
 
       - name: Run flake8
-        run: |
-          poetry run flake8
+        run: poetry run flake8
 
       - name: Run mypy
-        run: |
-          poetry run mypy vkbottle
+        run: poetry run mypy vkbottle
 
       - name: Run tests
-        run: |
-          poetry run pytest
+        run: poetry run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,10 @@ jobs:
           - 3.9
 
     steps:
-      - uses: actions/checkout@master
-
-      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v1
+      - uses: dhvcc/python-poetry-setup@v1
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install poetry
-        run: |
-          python -m pip install --upgrade pip poetry
-
-      - name: Install dependencies
-        run: |
-          poetry install
+          cache-key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run flake8
         run: |


### PR DESCRIPTION
Какую проблему решает ваш PR: Кеширование зависимостей в воркфлоу

~По сути это просто реюз уже написанного экшена, который хорошо кеширует установку pip, poetry, зависимостей от poetry install и, если есть, то установки pre-commit'a~

Что в этом PRе:
- Кеширование установки зависимостей (большое ускорение билда и меньше нагрузки на PyPi)
- Установка poetry через pipx (делает изолированное окружение). Установка поетри из пипа [не особо рекоммендуется](https://python-poetry.org/docs/#installing-with-pip)

----

Писал свой кастомный  экшен для этого, но вчера вышел релиз setup-python@v3, в котором уже есть логика для кеширования установки зависимостей poetry.