### PR TITLE
Фикс ошибки "int не может быть типом str"

### DIFF
--- a/vkbottle/framework/labeler/abc.py
+++ b/vkbottle/framework/labeler/abc.py
@@ -35,7 +35,7 @@ class ABCLabeler(ABC):
     def raw_event(
         self,
         event: Union[str, List[str], int],
-        dataclass: Optional[Any] = None,
+        dataclass: Any,
         *rules: "ABCRule",
         **custom_rules,
     ) -> "LabeledHandler":

--- a/vkbottle/framework/labeler/abc.py
+++ b/vkbottle/framework/labeler/abc.py
@@ -34,8 +34,8 @@ class ABCLabeler(ABC):
     @abstractmethod
     def raw_event(
         self,
-        event: Union[str, List[str]],
-        dataclass: Any,
+        event: Union[str, List[str], int],
+        dataclass: Optional[Any] = None,
         *rules: "ABCRule",
         **custom_rules,
     ) -> "LabeledHandler":


### PR DESCRIPTION
Этот PR фиксит неправильные типы в `on.raw_event(...)`

Связанные issue: #514.

* [x] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [x] Для вашего кода есть примеры использования в examples.
