### PR TITLE
Switch from `watchgod` to `watchfiles`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ choicelib = "^0.1.5"
 pydantic = "^1.9.1"
 vbml = "^1.1.post1"
 vkbottle-types = "^5.131.146.4"
-watchgod = "^0.8.2"
+watchfiles = "^0.14"
 aiofiles = "^0.8.0"
 typing-extensions = "^4.2.0"
 

--- a/vkbottle/tools/dev/auto_reload.py
+++ b/vkbottle/tools/dev/auto_reload.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from watchgod import awatch
+from watchfiles import awatch
 
 from vkbottle.modules import logger
 


### PR DESCRIPTION
`watchgod` переименовали в `watchfiles`.

См. README https://pypi.org/project/watchgod.