### PR TITLE
Fix `CommandRule` checking event.text

### DIFF
--- a/vkbottle/dispatch/rules/base.py
+++ b/vkbottle/dispatch/rules/base.py
@@ -76,13 +76,14 @@ class CommandRule(ABCRule[BaseMessageMin]):
 
     async def check(self, event: BaseMessageMin) -> Union[dict, bool]:
         for prefix in self.prefixes:
-            text_lenght = len(prefix + self.command_text)
-            text_lenght_with_sep = text_lenght + len(self.sep)
-            if self.args_count == 0 and len(event.text) == text_lenght:
-                return True
-            elif event.text.startswith(prefix + self.command_text + self.sep):
-                args = event.text[text_lenght_with_sep:].split(self.sep)
-                return {"args": args} if len(args) == self.args_count and all(args) else False
+            text_length = len(prefix + self.command_text)
+            text_length_with_sep = text_length + len(self.sep)
+            if event.text.startswith(prefix + self.command_text):
+                if not self.args_count and len(event.text) == text_length:
+                    return True
+                elif self.args_count and self.sep in event.text:
+                    args = event.text[text_length_with_sep:].split(self.sep)
+                    return {"args": args} if len(args) == self.args_count and all(args) else False
         return False
 
 


### PR DESCRIPTION
Какую проблему решает ваш PR: Во-первых исправил грамматическую ошибку в слове length. Во-вторых исправил ошибку совпадения длины команд (У меня было 2 обработчика, команды которых были равны по длине и бот всегда возвращал данные первому обработчику в коде).

Связанные issue: #577.
```diff
async def check(self, event: BaseMessageMin) -> Union[dict, bool]:
    for prefix in self.prefixes:
-   text_lenght = len(prefix + self.command_text)
-   text_lenght_with_sep = text_lenght + len(self.sep)
-   if self.args_count == 0 and len(event.text) == text_lenght:
-       return True
-   elif event.text.startswith(prefix + self.command_text + self.sep):
-       args = event.text[text_lenght_with_sep:].split(self.sep)
-       return {"args": args} if len(args) == self.args_count and all(args) else False
+   text_length = len(prefix + self.command_text)
+   text_length_with_sep = text_length + len(self.sep)
+   if event.text.startswith(prefix + self.command_text):
+       if not self.args_count and len(event.text) == text_length:
+           return True
+       elif self.args_count and self.sep in event.text:
+           args = event.text[text_length_with_sep:].split(self.sep)
+           return {"args": args} if len(args) == self.args_count and all(args) else False
    return False
```
![image](https://user-images.githubusercontent.com/105914205/196479277-b4650f84-1ec6-4b82-960c-47fa2b37cd77.png)