### PR TITLE
Add method in MessageEvent to remove loading spinner from callback button

### DIFF
--- a/examples/high-level/message_event.py
+++ b/examples/high-level/message_event.py
@@ -17,6 +17,8 @@ KEYBOARD = (
     .row()
     .add(Callback("Дата регистрации (tool42)", payload={"cmd": "app"}))
     .row()
+    .add(Callback("Ничего не делаю", payload={"cmd": "nothing"}))
+    .row()
     .add(Callback("Закрыть", payload={"cmd": "close"}))
     .get_json()
 )
@@ -43,6 +45,15 @@ async def show_snackbar(event: MessageEvent):
 )
 async def open_app(event: MessageEvent):
     await event.open_app(6798836, "reg", event.user_id)
+
+
+@bot.on.raw_event(
+    GroupEventType.MESSAGE_EVENT,
+    MessageEvent,
+    rules.PayloadRule({"cmd": "nothing"}),
+)
+async def do_nothing(event: MessageEvent):
+    await event.send_empty_answer()
 
 
 @bot.on.raw_event(

--- a/vkbottle/tools/mini_types/bot/message_event.py
+++ b/vkbottle/tools/mini_types/bot/message_event.py
@@ -47,6 +47,15 @@ class MessageEventMin(MessageEvent):
         data.update(kwargs)
         return (await self.ctx_api.request("messages.sendMessageEventAnswer", data))["response"]
 
+    async def send_empty_answer(self, **kwargs) -> int:
+        data = {
+            "event_id": self.event_id,
+            "user_id": self.user_id,
+            "peer_id": self.peer_id,
+        }
+        data.update(kwargs)
+        return (await self.ctx_api.request("messages.sendMessageEventAnswer", data))["response"]
+
     async def show_snackbar(self, text: str) -> int:
         return await self.send_message_event_answer(ShowSnackbarEvent(text=text))
 


### PR DESCRIPTION
Какую проблему решает ваш PR: Добавил метод, который отправляет пустой message_event_answer, который убирает загрузку (спинер) из Callback кнопки. Обновил example.

* [X] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [X] Для вашего кода есть примеры использования в examples.
