### PR TITLE
Fix SingleAiohttpClient TypeError

### DIFF
--- a/vkbottle/http/aiohttp.py
+++ b/vkbottle/http/aiohttp.py
@@ -100,7 +100,7 @@ class AiohttpClient(ABCHTTPClient):
 class SingleAiohttpClient(AiohttpClient):
     __instance__: Optional[Self] = None
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:  # noqa: ARG003
         if cls.__instance__ is None:
             cls.__instance__ = super().__new__(cls)
         return cls.__instance__  # type: ignore[return-value]

--- a/vkbottle/http/aiohttp.py
+++ b/vkbottle/http/aiohttp.py
@@ -102,7 +102,7 @@ class SingleAiohttpClient(AiohttpClient):
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         if cls.__instance__ is None:
-            cls.__instance__ = super().__new__(cls, *args, **kwargs)
+            cls.__instance__ = super().__new__(cls)
         return cls.__instance__  # type: ignore[return-value]
 
     async def __aexit__(


### PR DESCRIPTION
```python
from vkbottle import SingleAiohttpClient

SingleAiohttpClient(connector=None)
```

```python
    cls.__instance__ = super().__new__(cls, *args, **kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```