### PR TITLE
wall photo upload fix

### DIFF
--- a/vkbottle/tools/uploader/photo.py
+++ b/vkbottle/tools/uploader/photo.py
@@ -105,7 +105,7 @@ class PhotoWallUploader(PhotoUploader):
         return photos[0]
 
     async def get_server(self, **kwargs) -> dict:
-        return (await self.api.request("photos.getWallUploadServer", {}))["response"]
+        return (await self.api.request("photos.getWallUploadServer", kwargs))["response"]
 
 
 class PhotoFaviconUploader(PhotoUploader):


### PR DESCRIPTION
Какую проблему решает ваш PR: В `PhotoWallUploader` `kwargs` не передается в `photos.getWallUploadServer`. Из-за этого, если передать `group_id` в аплоад, это приведет к ошибке 121 - Invalid hash - этот пр должен это пофиксить.

Связанные issue: # .

* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
