### PR TITLE
fix unrelatable deprecation warnings

### DIFF
--- a/vkbottle/bot.py
+++ b/vkbottle/bot.py
@@ -15,6 +15,7 @@ MessageEvent = MessageEventMin
     "Blueprints was deprecated and will be removed in future releases, "
     "read about new code separation method in documentation: \n"
     "https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/",
+    category=FutureWarning,
     stacklevel=0,
 )
 class Blueprint(BotBlueprint): ...

--- a/vkbottle/framework/abc_blueprint.py
+++ b/vkbottle/framework/abc_blueprint.py
@@ -17,6 +17,7 @@ CONSTRUCT_BLUEPRINT = "You need to construct blueprint firstly"
     "Blueprints was deprecated and will be removed in future releases, "
     "read about new code separation method in documentation: \n"
     "https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/",
+    category=FutureWarning,
     stacklevel=0,
 )
 class ABCBlueprint(ABCFramework):

--- a/vkbottle/framework/bot/blueprint.py
+++ b/vkbottle/framework/bot/blueprint.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     "Blueprints was deprecated and will be removed in future releases, "
     "read about new code separation method in documentation: \n"
     "https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/",
+    category=FutureWarning,
     stacklevel=0,
 )
 class BotBlueprint(ABCBlueprint):

--- a/vkbottle/framework/user/blueprint.py
+++ b/vkbottle/framework/user/blueprint.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     "Blueprints was deprecated and will be removed in future releases, "
     "read about new code separation method in documentation: \n"
     "https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/",
+    category=FutureWarning,
     stacklevel=0,
 )
 class UserBlueprint(ABCBlueprint):

--- a/vkbottle/modules.py
+++ b/vkbottle/modules.py
@@ -28,7 +28,6 @@ json: JSONModule = choice_in_order(
     default="json",
 )
 
-warnings.simplefilter("always", DeprecationWarning)
 showwarning_ = warnings.showwarning
 
 

--- a/vkbottle/tools/dev/__init__.py
+++ b/vkbottle/tools/dev/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 warnings.warn(
     "Imports from vkbottle.tools.dev is deprecated, use vkbottle.tools instead",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=0,
 )
 

--- a/vkbottle/tools/loop_wrapper.py
+++ b/vkbottle/tools/loop_wrapper.py
@@ -35,6 +35,7 @@ class LoopWrapper:
     @property
     @deprecated(
         "LoopWrapper.auto_reload is deprecated, instead, install watchfiles",
+        category=FutureWarning,
         stacklevel=0,
     )
     def auto_reload(self) -> bool:
@@ -44,12 +45,13 @@ class LoopWrapper:
     def auto_reload(self, value: bool) -> None:
         warnings.warn(
             "LoopWrapper.auto_reload is deprecated, instead, install watchfiles",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=0,
         )
 
     @deprecated(
         "Deprecated. Use run() instead",
+        category=FutureWarning,
         stacklevel=0,
     )
     def run_forever(self):

--- a/vkbottle/tools/uploader/base.py
+++ b/vkbottle/tools/uploader/base.py
@@ -26,7 +26,7 @@ class BaseUploader(ABC):
             warnings.warn(
                 "generate_attachment_strings in uploaders is deprecated"
                 " use .raw_upload() to get raw response or .upload() to get attachment string",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=0,
             )
             kwargs.pop("generate_attachment_strings")

--- a/vkbottle/user.py
+++ b/vkbottle/user.py
@@ -14,6 +14,7 @@ Message = MessageMin
     "Blueprints was deprecated and will be removed in future releases, "
     "read about new code separation method in documentation: \n"
     "https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/",
+    category=FutureWarning,
     stacklevel=0,
 )
 class Blueprint(UserBlueprint): ...


### PR DESCRIPTION
Какую проблему решает ваш PR: неотключаемые DeprecationWarning

На данный момент при использовании vkbottle показываются такие предупреждения:

> DeprecationWarning: Blueprints was deprecated and will be removed in future releases, read about new code separation method in documentation: 
https://vkbottle.rtfd.io/ru/latest/tutorial/code-separation/

Они появляются, даже если не использовать `Blueprints`, а все потому, что он импортируется внутри самой библиотеки и потому что в модуле `vkbottle.modules` есть такая строчка:
https://github.com/vkbottle/vkbottle/blob/0eed965d3c3270770d23f8297331f1a626af284d/vkbottle/modules.py#L31

Ну и отключить их через `warnings.simplefilter("ignore", DeprecationWarning)` не удается

Поэтому предлагаю поменять все DeprecationWarning на [FutureWarning](https://docs.python.org/3/library/exceptions.html#FutureWarning), как это например уже делает [scikit-learn](https://scikit-learn.org/0.22/whats_new/v0.22.html#deprecations-using-futurewarning-from-now-on)