### PR TITLE
Update logging level for middleware errors in pre_middleware

### DIFF
--- a/vkbottle/dispatch/views/abc/view.py
+++ b/vkbottle/dispatch/views/abc/view.py
@@ -42,7 +42,7 @@ class ABCView(ABC, Generic[T_contra]):
             mw_instance = middleware(event, view=self)
             await mw_instance.pre()
             if not mw_instance.can_forward:
-                logger.debug("{} pre returned error {}", mw_instance, mw_instance.error)
+                logger.error("{} pre returned error {}", mw_instance, mw_instance.error)
                 return None
 
             mw_instances.append(mw_instance)


### PR DESCRIPTION
Какую проблему решает ваш PR: Errors in the middleware should be logged as 'error' to make them more visible and easier to track. Logging them as 'debug' may cause important issues to be overlooked

Связанные issue: # .

* [] Ваш код документирован.
* [] Для вашего кода есть тесты.
* [] Для вашего кода есть примеры использования в examples.

#1055 
