### PR TITLE
Fix/remove basic config

### DIFF
--- a/tests/fixtures/middlewares.py
+++ b/tests/fixtures/middlewares.py
@@ -11,16 +11,16 @@ class EmptyMiddleware(BaseMiddleware):
         pass
 
 
-@pytest.fixture()
+@pytest.fixture
 def empty_middleware_class():
     return EmptyMiddleware
 
 
-@pytest.fixture()
+@pytest.fixture
 def empty_event():
     return {}
 
 
-@pytest.fixture()
+@pytest.fixture
 def empty_middleware_instance(empty_middleware_class, empty_event):
     return empty_middleware_class(empty_event)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ class MockedRescheduler(ABCRequestRescheduler):
         return self.final_response
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(USERS_GET_RESPONSE)
 async def test_api_raw_response(api: API):
     response = await api.request("users.get", {"user_ids": 1})
@@ -31,7 +31,7 @@ async def test_api_raw_response(api: API):
     assert response["response"][0]["first_name"] == "Павел"
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(USERS_GET_RESPONSE)
 async def test_api_typed_response(api: API):
     response = await api.users.get(1)  # type: ignore
@@ -40,7 +40,7 @@ async def test_api_typed_response(api: API):
     assert response[0].first_name == "Павел"
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api('{"error":{"error_code":0,"error_msg":"Some Error!","request_params":[]}}')
 async def test_vk_api_error_handling(api: API):
     try:
@@ -50,7 +50,7 @@ async def test_vk_api_error_handling(api: API):
     raise AssertionError
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(
     '{"error":{"error_code":14,"error_msg":"Captcha needed","request_params":'
     '[{"key":"oauth","value":"1"},{"key":"method","value":"captcha.force"},{"key":"uids",'
@@ -90,7 +90,7 @@ async def test_auth_blocked_user_error_handling(api: API):
     }
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(
     '{"error": {"error_code":5, '
     '"error_msg": "User authorization failed: invalid access_token (4).", '
@@ -107,7 +107,7 @@ async def test_auth_error_handling(api: API):
     assert not e.value.ban_info
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(None)
 async def test_api_invalid_response(api: API):
     api.request_rescheduler = MockedRescheduler(None, {"response": {"some": "response"}})
@@ -115,21 +115,21 @@ async def test_api_invalid_response(api: API):
     assert response == {"response": {"some": "response"}}
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(1)
 async def test_response_validators(api: API):
     api.response_validators = []
     assert await api.request("some.method", {}) == 1
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api('{"error":{"error_code":5,"error_msg":"Some error occurred!"}}')
 async def test_ignore_errors(api: API):
     api.ignore_errors = True
     assert await api.request("some.method", {}) is None
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api('{"response":1}')
 async def test_request_many(api: API):
     i = 0
@@ -141,13 +141,13 @@ async def test_request_many(api: API):
     assert i == 2
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_types_translator():
     api = API("token")
     assert await api.validate_request({"a": [1, 2, 3, 4, "hi!"]}) == {"a": "1,2,3,4,hi!"}
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(
     '{"error": {"error_code": 10, "error_msg": "Internal server error: Unknown error, try later"}}'
 )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -154,7 +154,7 @@ async def test_bot_polling():  # noqa: C901
         break
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_scopes():
     bot = Bot(token="some token")
     assert await bot.api.token_generator.get_token() == "some token"
@@ -189,7 +189,7 @@ def fake_message(ctx_api: API, **data: Any) -> Message:
     )
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @with_mocked_api(None)
 async def test_rules(api: API):
     assert await base.FromPeerRule(123).check(fake_message(api, peer_id=123))

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -17,7 +17,7 @@ def test_code_error():
         assert e.code == 1  # noqa: PT017
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_error_handler():
     class Base(Exception):
         pass
@@ -41,7 +41,7 @@ async def test_error_handler():
     assert await func() == 42
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_error_handler_with_code_exception():
     class CodeError(CodeException):
         pass

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,7 @@ from tests.test_utils import MockedClient
 from vkbottle.http import AiohttpClient
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_client():
     client = MockedClient("some text")
     text = await client.request_text("https://example.com")
@@ -12,7 +12,7 @@ async def test_client():
     assert text == "some text"
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_client_init():
     client = AiohttpClient(test="test")
     assert client._session_params["test"] == "test"

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -32,7 +32,7 @@ def test_middleware_constructs_without_pre_and_post(empty_event):
     IncompleteMiddleware(empty_event)
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_raise_in_pre_sets_error(empty_middleware_class, empty_event):
     expected_exception = Exception("some_exception")
 
@@ -52,7 +52,7 @@ async def test_raise_in_pre_sets_error(empty_middleware_class, empty_event):
     assert middleware.error == expected_exception
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_cant_forward_on_error(empty_middleware_class, empty_event):
     class SomeMiddleware(empty_middleware_class):
         async def pre(self, *args, **kwargs):
@@ -64,7 +64,7 @@ async def test_cant_forward_on_error(empty_middleware_class, empty_event):
     assert middleware.can_forward is False
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_view_middleware_utils_run(empty_event):
     view = BotMessageView()
     mw_instances = await view.pre_middleware(empty_event, {})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,7 +16,7 @@ class SomeView(ABCView):
         pass
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_pre_post_middleware_returns_exception(empty_event):
     expected_error = Exception()
 

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -156,7 +156,7 @@ def test_template_generator():
     )
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_validators():
     assert await IsInstanceValidator((int, str)).check("foo")
     assert not await EqualsValidator("foo").check("bar")
@@ -188,7 +188,7 @@ def test_loop_wrapper():
     ]
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_utils(mocker: "MockerFixture"):
     async def task_to_run(s, y):
         ctx_storage.set("checked-test-lw-create-task", "task_to_run")

--- a/vkbottle/modules.py
+++ b/vkbottle/modules.py
@@ -175,7 +175,6 @@ elif logging_module == "logging":
     warnings.showwarning = showwarning
 
     logger = StyleAdapter(logging.getLogger("vkbottle"))  # type: ignore
-    logger.info("logging is used as the default logger, but we recommend using loguru instead")
 
 if hasattr(asyncio, "WindowsProactorEventLoopPolicy") and isinstance(
     asyncio.get_event_loop_policy(),

--- a/vkbottle/modules.py
+++ b/vkbottle/modules.py
@@ -138,8 +138,6 @@ elif logging_module == "logging":
                 style="{",
             ).format(record)
 
-    logging.root.handlers[0].setFormatter(ColorFormatter())
-
     class LogMessage:
         def __init__(self, fmt, args, kwargs):
             self.fmt = fmt
@@ -173,7 +171,13 @@ elif logging_module == "logging":
 
     warnings.showwarning = showwarning
 
-    logger = StyleAdapter(logging.getLogger("vkbottle"))  # type: ignore
+    _logger = logging.getLogger("vkbottle")
+    if not _logger.handlers:
+        console_handler = logging.StreamHandler()
+        _logger.addHandler(console_handler)
+
+    _logger.handlers[0].setFormatter(ColorFormatter())
+    logger = StyleAdapter(_logger)  # type: ignore
 
 if hasattr(asyncio, "WindowsProactorEventLoopPolicy") and isinstance(
     asyncio.get_event_loop_policy(),

--- a/vkbottle/modules.py
+++ b/vkbottle/modules.py
@@ -138,7 +138,6 @@ elif logging_module == "logging":
                 style="{",
             ).format(record)
 
-    logging.basicConfig(level=logging.DEBUG)
     logging.root.handlers[0].setFormatter(ColorFormatter())
 
     class LogMessage:


### PR DESCRIPTION
Какую проблему решает ваш PR:
Refactor the code so that `logging.basicConfig` is not set within the library. Instead, allow users to apply their own custom configuration settings for logging or other configuration. 

**Changes are applied only for the logging library.**

Связанные issue: #1061

* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
