### PR TITLE
Formatting  UTF-16

### DIFF
--- a/docs/tools/formatting.md
+++ b/docs/tools/formatting.md
@@ -33,7 +33,7 @@ Formatter("Hi, {name}.").format(name="Maria")  # Hi, Maria.
 Пример использования:
 ```python
 Formatter("{:bold}, nice formatting!").format("Wow")  # Wow, nice formatting!
-Formatter("{framefork:italic} has been around for over 5 years!").format(framework="vkbottle")  # vkbottle has been around for over 5 years!
+Formatter("{framework:italic} has been around for over 5 years!").format(framework="vkbottle")  # vkbottle has been around for over 5 years!
 ```
 
 Для того, чтобы объединить типы форматов, используется синтаксис объединения через символ `+`.
@@ -43,7 +43,7 @@ Formatter("Very cool {:bold+italic} ^_^").format("bold-italic message")  # Very 
 
 Метод `format_map` работает так же, как и `format`, за исключением того, что метод принимает один аргумент типа `Mapping`, который передается в метод `format`.
 ```python
-Formatter("My bestie is {bestie:underline}").format(bestie="telegrinder")  # My bestie is telegrinder
+Formatter("My bestie is {bestie:underline}").format_map({"bestie": "telegrinder")  # My bestie is telegrinder
 ```
 
 Объект `Formatter` имеет 2 свойства для того, чтобы получить форматирование в виде `json`:

--- a/tests/tools/test_formatting.py
+++ b/tests/tools/test_formatting.py
@@ -1,0 +1,245 @@
+from vkbottle.tools import Formatter, bold, italic, underline, url
+
+
+def test_docs_formatter():
+    f1 = Formatter("{:bold}, nice formatting!").format("Wow")
+    assert f1.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "bold", "offset": 0, "length": 3}],
+    }
+
+    f2 = Formatter("{framework:italic} has been around for over 5 years!").format(
+        framework="vkbottle"
+    )
+    assert f2.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 0, "length": 8}],
+    }
+
+    f3 = Formatter("Very cool {:bold+italic} ^_^").format("bold-italic message")
+    assert f3.format_data == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 10, "length": 19},
+            {"type": "italic", "offset": 10, "length": 19},
+        ],
+    }
+
+    f4 = Formatter("My bestie is {bestie:underline}").format_map({"bestie": "telegrinder"})
+    assert f4.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "underline", "offset": 13, "length": 11}],
+    }
+
+
+def test_docs_funcs():
+    s1 = bold("Hello, ") + italic("World!")
+    assert s1.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 0, "length": 7},
+            {"type": "italic", "offset": 7, "length": 6},
+        ],
+    }
+
+    s2 = "Hello, " + italic("World!")
+    assert s2.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 7, "length": 6}],
+    }
+
+    s3 = bold("Hello") + ", " + italic("World!")
+    assert s3.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 0, "length": 5},
+            {"type": "italic", "offset": 7, "length": 6},
+        ],
+    }
+
+    s4 = (
+        bold("vkbottle documentation:")
+        + " "
+        + url(italic("click me"), href="vkbottle.readthedocs.io/ru/latest")
+    )
+    assert s4.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 0, "length": 23},
+            {
+                "type": "italic",
+                "offset": 24,
+                "length": 8,
+                "url": "vkbottle.readthedocs.io/ru/latest",
+            },
+            {"type": "italic", "offset": 24, "length": 8},
+        ],
+    }
+
+
+def test_utf16_formatter():
+    s1 = Formatter("{:bold}, 🌍").format("Hello")
+    assert s1.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "bold", "offset": 0, "length": 5}],
+    }
+
+    s2 = Formatter("👋, {:bold}!").format("world")
+    assert s2.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "bold", "offset": 4, "length": 5}],
+    }
+
+    s3 = Formatter("😊{:italic}").format("face")
+    assert s3.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 2, "length": 4}],
+    }
+
+    s4 = Formatter("{:bold}x😊x{:italic}").format("Smily", "face")
+    assert s4.format_data == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 0, "length": 5},
+            {"type": "italic", "offset": 9, "length": 4},
+        ],
+    }
+
+    s5 = Formatter("🌟Reach the {:bold}\nFly me to the 🚀 {:italic+bold}!").format(
+        "stars!", "moon"
+    )
+    assert s5.format_data == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 12, "length": 6},
+            {"type": "italic", "offset": 36, "length": 4},
+            {"type": "bold", "offset": 36, "length": 4},
+        ],
+    }
+
+    s6 = Formatter("Café ☕️ - xx{from_french:underline}xx").format_map(
+        {"from_french": "is a Cafe!"}
+    )
+    assert s6.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "underline", "offset": 12, "length": 10}],
+    }
+
+    s7 = Formatter("😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚 - a x{:italic}x of emojies").format("bunch")
+    assert s7.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 40, "length": 5}],
+    }
+
+    s8 = Formatter("こんにちは ({japanize:italic}) 🌸").format_map({"japanize": "Konnichiwa"})
+    assert s8.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 7, "length": 10}],
+    }
+
+    s9 = Formatter("{:underline}").format("underlined 🌸")
+    assert s9.format_data == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "underline", "offset": 0, "length": 12}],
+    }
+
+
+def test_utf16_format_func():
+    s1 = bold("Hello") + ", 🌍"
+    assert s1.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "bold", "offset": 0, "length": 5}],
+    }
+
+    s2 = "👋, " + bold("world")
+    assert s2.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "bold", "offset": 4, "length": 5}],
+    }
+
+    s3 = "😊" + italic("face")
+    assert s3.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 2, "length": 4}],
+    }
+
+    s4 = bold("smily") + "x😊x" + italic("face")
+    assert s4.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 0, "length": 5},
+            {"type": "italic", "offset": 9, "length": 4},
+        ],
+    }
+
+    s5 = "🌟Reach the " + bold("stars!") + "\nFly me to the 🚀 " + italic(bold("moon")) + "!"
+    assert s5.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [
+            {"type": "bold", "offset": 12, "length": 6},
+            {"type": "italic", "offset": 36, "length": 4},
+            {"type": "bold", "offset": 36, "length": 4},
+        ],
+    }
+
+    from_french = "is a Cafe!"
+    s6 = "Café ☕️ - xx" + underline(from_french) + "xx"
+    assert s6.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "underline", "offset": 12, "length": 10}],
+    }
+
+    s7 = "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚 - a x" + italic("bunch") + "x of emojies"
+    assert s7.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 40, "length": 5}],
+    }
+
+    japanize = "Konnichiwa"
+    s8 = "こんにちは (" + italic(japanize) + ") 🌸"
+    assert s8.as_data() == {
+        "version": Formatter.VERSION,
+        "items": [{"type": "italic", "offset": 7, "length": 10}],
+    }
+
+
+def test_functional_equivalence():
+    funcs_1 = bold("Hello") + ", 🌍"
+    formatter_1 = Formatter("{:bold}, 🌍").format("Hello")
+    assert funcs_1.as_data() == formatter_1.format_data
+
+    funcs_2 = "👋, " + bold("world")
+    formatter_2 = Formatter("👋, {:bold}!").format("world")
+    assert funcs_2.as_data() == formatter_2.format_data
+
+    funcs_3 = "😊" + italic("face")
+    formatter_3 = Formatter("😊{:italic}").format("face")
+    assert funcs_3.as_data() == formatter_3.format_data
+
+    funcs_4 = bold("smily") + "x😊x" + italic("face")
+    formatter_4 = Formatter("{:bold}x😊x{:italic}").format("smily", "face")
+    assert funcs_4.as_data() == formatter_4.format_data
+
+    funcs_5 = "🌟Reach the " + bold("stars!") + "\nFly me to the 🚀 " + italic(bold("moon")) + "!"
+    formatter_5 = Formatter("🌟Reach the {:bold}\nFly me to the 🚀 {:italic+bold}!").format(
+        "stars!", "moon"
+    )
+    assert funcs_5.as_data() == formatter_5.format_data
+
+    from_french = "is a Cafe!"
+    funcs_6 = "Café ☕️ - xx" + underline(from_french) + "xx"
+    formatter_6 = Formatter("Café ☕️ - xx{from_french:underline}xx").format_map(
+        {"from_french": from_french}
+    )
+    assert funcs_6.as_data() == formatter_6.format_data
+
+    funcs_7 = "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚 - a x" + italic("bunch") + "x of emojies"
+    formatter_7 = Formatter(
+        "😀😁😂🤣😃😄😅😆😉😊😋😎😍😘😗😙😚 - a x{:italic}x of emojies"
+    ).format("bunch")
+    assert funcs_7.as_data() == formatter_7.format_data
+
+    japanize = "Konnichiwa"
+    funcs_8 = "こんにちは (" + italic(japanize) + ") 🌸"
+    formatter_8 = Formatter("こんにちは ({japanize:italic}) 🌸").format_map({"japanize": japanize})
+    assert funcs_8.as_data() == formatter_8.format_data


### PR DESCRIPTION
Какую проблему решает ваш PR:
При использовании Formatter и функций bold, italic, underline и link в сообщениях с символами не попадающих в один UTF-16 получалось неверное отображение сообщения.
```python3
text = Formatter('{:bold} 💚\nСпасибо большое за участие!?😅\nНадеемся, вам очень понравилось:\n{:bold}\n\nДля этого просто:\n📲 Опубликуй пост у себя на страничке в {:bold}\n.  Добавь хештег {:bold}\n🎁 И {:bold} — возможно, получишь классный приз!!\n\n').format('Ура, вот и всё!', 'Участвуй в розыгрыше призов от vkbottle!', 'VK', '#ДлинныйХэштег', 'жди результаты')

await message.answer(text)
```
<img width="686" height="250" alt="image" src="https://github.com/user-attachments/assets/649540dc-90dc-4ce8-acc5-38233e587fe6" />


Об этом есть [пометка](https://dev.vk.com/en/reference/objects/message#format_data) в документации VK API. 

Результат:
<img width="658" height="287" alt="image" src="https://github.com/user-attachments/assets/6bcbf41c-2586-4b41-8ad2-95219707f5ad" />


Плюс, поправил примеры в документации [Formatting](https://vkbottle.readthedocs.io/ru/latest/tools/formatting/).

Связанные issue: # _Решил не открывать Issue, быстро разобрался сам_

* [x] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [x] Для вашего кода есть примеры использования в examples.