### PR TITLE
 прокидывание error_handler во View + redirect аргументов

### DIFF
--- a/vkbottle/dispatch/base.py
+++ b/vkbottle/dispatch/base.py
@@ -34,4 +34,6 @@ class Router(ABCRouter):
         self.views = views
         self.state_dispenser = state_dispenser
         self.error_handler = error_handler
+        for view in self.views.values():
+            view.error_handler = error_handler  # type: ignore[attr-defined]
         return self

--- a/vkbottle/dispatch/views/abc/message.py
+++ b/vkbottle/dispatch/views/abc/message.py
@@ -72,7 +72,11 @@ class ABCMessageView(ABCDispenseView[T_contra, F_contra], ABC, Generic[T_contra,
             elif isinstance(result, dict):
                 context_variables.update(result)
 
-            handler_response = await handler.handle(message, **context_variables)
+            try:
+                handler_response = await handler.handle(message, **context_variables)
+            except Exception as e:
+                await self._get_error_handler().handle(e, message, **context_variables)
+                continue
             handle_responses.append(handler_response)
             handlers.append(handler)
 

--- a/vkbottle/dispatch/views/abc/raw.py
+++ b/vkbottle/dispatch/views/abc/raw.py
@@ -75,10 +75,14 @@ class ABCRawEventView(ABCView[Event_contra], Generic[Event_contra, HandlerBaseme
             elif isinstance(result, dict):
                 context_variables.update(result)
 
-            handler_response = await handler_basement.handler.handle(
-                event_model,
-                **context_variables,
-            )
+            try:
+                handler_response = await handler_basement.handler.handle(
+                    event_model,
+                    **context_variables,
+                )
+            except Exception as e:
+                await self._get_error_handler().handle(e, event_model, **context_variables)
+                continue
             handle_responses.append(handler_response)
             handlers.append(handler_basement.handler)
 

--- a/vkbottle/dispatch/views/abc/view.py
+++ b/vkbottle/dispatch/views/abc/view.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from vkbottle.dispatch.dispenser.abc import ABCStateDispenser
     from vkbottle.dispatch.handlers import ABCHandler
     from vkbottle.dispatch.return_manager import BaseReturnManager
+    from vkbottle.exception_factory import ABCErrorHandler
 
     Handlers = Union[List["ABCHandler[Any]"], Dict[Any, List]]
 
@@ -25,6 +26,14 @@ class ABCView(ABC, Generic[T_contra]):
         self.handlers = []
         self.middlewares = []
         self.handler_return_manager = None  # type: ignore
+        self.error_handler: Optional["ABCErrorHandler"] = None  # type: ignore[assignment]
+
+    def _get_error_handler(self) -> "ABCErrorHandler":
+        if self.error_handler is None:
+            from vkbottle.exception_factory.error_handler import ErrorHandler
+
+            self.error_handler = ErrorHandler()
+        return self.error_handler
 
     @abstractmethod
     async def process_event(self, event: T_contra) -> bool:

--- a/vkbottle/exception_factory/error_handler/abc.py
+++ b/vkbottle/exception_factory/error_handler/abc.py
@@ -25,7 +25,7 @@ class ABCErrorHandler(ABC):
         pass
 
     @abstractmethod
-    async def handle(self, error: Exception) -> Any:
+    async def handle(self, error: Exception, *args: Any, **kwargs: Any) -> Any:
         pass
 
     @abstractmethod


### PR DESCRIPTION
fix: https://github.com/vkbottle/vkbottle/issues/772

Какую проблему решает ваш PR: ... Bot error handler doesn't redirect argument

если хендлер сообщения/события выбросит исключение, View перехватит его и вызовет error_handler.handle(...), передав туда исходные аргументы хендлера (сообщение/ивент и контекст из правил/мидлварей), когда redirect_arguments=True.
поэтому зарегистрированый обработчик ошибки сможет получить те же аргументы, что и упавший хендлер, а не только саму ошибку

Связанные issue: # https://github.com/vkbottle/vkbottle/issues/772


* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
