### PR TITLE
fix: use inspect.signature in _resolve_arg_names

### DIFF
--- a/vkbottle/tools/magic.py
+++ b/vkbottle/tools/magic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from inspect import signature
 
 Function = typing.Callable[..., typing.Any]
 
@@ -20,8 +21,12 @@ def _resolve_arg_names(
     exclude: set[str] | None = None,
 ) -> tuple[str, ...]:
     exclude = exclude or set()
-    varnames = func.__code__.co_varnames[start_idx:stop_idx]
-    return tuple(name for name in varnames if name not in exclude)
+
+    return tuple(
+        p.name
+        for p in signature(func).parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD) and p.name not in exclude
+    )[start_idx:stop_idx]
 
 
 def resolve_arg_names(


### PR DESCRIPTION
Какую проблему решает ваш PR: функция tools.magic._resolve_arg_names использует `func.__code__.co_varnames[start_idx:stop_idx]`, которая не может найти аргументы для функций, обёрнутых декоратором с `functools.wraps`: в таких случаях `func.__code__` ссылается на обёртку, и имена аргументов исходного хендлера недоступны. 
Это критично, поскольку, например, из-за этого функция tools.magic.magic_bundle, используемая в vkbottle.dispatch.handlers.from_func_handler.FromFuncHandler, не даёт обёрнутому  в несколько кастомных декораторов хендлеру получить переменные контекста. 
Для этого конструкция заменяется на использование `inspect.signature`, позволяющая получить аргументы даже к обёрнутым в кастомные декораторы хендлерам.


* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
