### PR TITLE
fix: replace polling stop bool flag with asyncio.Event (#790)

### DIFF
--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,85 @@
+import pytest
+
+from tests.test_utils import MockedClient
+from vkbottle import API
+from vkbottle.polling.bot_polling import BotPolling
+
+EXAMPLE_EVENT = {
+    "ts": 1,
+    "updates": [
+        {
+            "type": "message_new",
+            "object": {},
+        },
+    ],
+}
+
+
+def make_bot_polling() -> tuple[BotPolling, API]:
+    call_count = 0
+
+    def callback(method: str, url: str, data: dict):
+        nonlocal call_count
+
+        if "groups.getById" in url:
+            return {"response": {"groups": [{"id": 1}]}}
+        if "groups.getLongPollServer" in url:
+            return {"response": {"ts": 1, "server": "!SERVER!", "key": ""}}
+        if "!SERVER!" in url:
+            call_count += 1
+            return {**EXAMPLE_EVENT, "ts": call_count}
+
+        return {}
+
+    api = API("token")
+    api.http_client = MockedClient(callback=callback)
+
+    polling = BotPolling(api=api)
+    return polling, api
+
+
+@pytest.mark.asyncio
+async def test_stop_terminates_listen():
+    """stop() should terminate the listen() loop."""
+    polling, _ = make_bot_polling()
+    events = []
+
+    async for event in polling.listen():
+        events.append(event)
+        polling.stop()
+
+    assert len(events) == 1
+    assert events[0]["updates"] == EXAMPLE_EVENT["updates"]
+
+
+@pytest.mark.asyncio
+async def test_listen_works_after_stop():
+    """listen() should work again after a previous stop()."""
+    polling, _ = make_bot_polling()
+
+    async for _event in polling.listen():
+        polling.stop()
+        break
+
+    events = []
+
+    async for event in polling.listen():
+        events.append(event)
+        polling.stop()
+
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_before_listen_is_noop():
+    """Calling stop() before listen() should not raise."""
+    polling, _ = make_bot_polling()
+    polling.stop()
+
+    events = []
+
+    async for event in polling.listen():
+        events.append(event)
+        polling.stop()
+
+    assert len(events) == 1

--- a/vkbottle/polling/abc.py
+++ b/vkbottle/polling/abc.py
@@ -36,6 +36,10 @@ class ABCPolling(ABC):
         pass
 
     @abstractmethod
+    def stop(self) -> None:
+        pass
+
+    @abstractmethod
     def construct(
         self,
         api: "ABCAPI",

--- a/vkbottle/polling/bot_polling.py
+++ b/vkbottle/polling/bot_polling.py
@@ -30,7 +30,6 @@ class BotPolling(BasePolling):
         self.group_id = group_id
         self.wait = min(wait or 25, 90)
         self.rps_delay = rps_delay or 0
-        self.stop = False
 
     async def get_event(self, server: dict[str, Any]) -> dict[str, Any]:
         # sourcery skip: use-fstring-for-formatting

--- a/vkbottle/polling/user_polling.py
+++ b/vkbottle/polling/user_polling.py
@@ -36,7 +36,6 @@ class UserPolling(BasePolling):
         self.rps_delay = rps_delay or 0
         self.lp_version = lp_version or 3
         self.need_pts = need_pts
-        self.stop = False
 
     async def get_event(self, server: dict[str, Any]) -> dict[str, Any]:
         # sourcery skip: use-fstring-for-formatting


### PR DESCRIPTION
Какую проблему решает ваш PR:
- Заменяет изменяемый `self.stop` с `bool` на опциональный `asyncio.Event` в классах Polling.
- Добавляет метод `stop()`, для: `ABCPolling` и `BasePolling`
- Изменена логика, при которой `listen()` теперь создает новое событие, учтены циклы запуска-остановки-запуска-....
- Добавляет тесты для следующий ситуаций:
  - `stop()` завершает цикл `listen()`.
  - Повторный `listen()` после `stop()` работает.
  - `stop()` до `listen()` не нарушает работу.
  - Существующий `test_bot_polling` проходит без изменений.

Связанные issue: #790 .
> Ну либо мною не так понят его смысл.

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
