### PR TITLE
feat: add get_full_message() to ForeignMessageMin

### DIFF
--- a/examples/high-level/forward_message_example.py
+++ b/examples/high-level/forward_message_example.py
@@ -1,0 +1,47 @@
+import os
+
+from vkbottle.bot import Bot, Message
+
+bot = Bot(os.environ["TOKEN"])
+
+
+async def process_foreign_messages(message: Message) -> str:
+    """Recursively processes forwarded messages, loading full content for each."""
+    lines = []
+
+    async def walk(fwd_messages, depth=0):
+        for fwd in fwd_messages:
+            # Load full message data (attachments, full text, etc.)
+            await fwd.get_full_message()
+
+            prefix = "  " * depth
+            attachments = fwd.get_attachment_strings() or []
+
+            lines.append(
+                f"{prefix}[{fwd.from_id}]: {fwd.text}"
+                + (f" (attachments: {', '.join(attachments)})" if attachments else "")
+            )
+
+            if fwd.fwd_messages:
+                await walk(fwd.fwd_messages, depth + 1)
+
+    if message.reply_message:
+        await message.reply_message.get_full_message()
+        lines.append(f"Reply to [{message.reply_message.from_id}]: {message.reply_message.text}")
+
+    if message.fwd_messages:
+        await walk(message.fwd_messages)
+
+    return "\n".join(lines)
+
+
+@bot.on.message()
+async def handler(message: Message):
+    if not message.fwd_messages and not message.reply_message:
+        return
+
+    result = await process_foreign_messages(message)
+    await message.answer(f"Forwarded messages:\n{result}")
+
+
+bot.run_forever()

--- a/tests/test_foreign_message.py
+++ b/tests/test_foreign_message.py
@@ -1,0 +1,110 @@
+from typing import Any
+
+import pytest
+
+from tests.test_utils import MockedClient
+from vkbottle import API
+from vkbottle.tools.mini_types.bot.foreign_message import ForeignMessageMin
+
+
+def fake_foreign_message(ctx_api: API, **data: Any) -> ForeignMessageMin:
+    message = {
+        "peer_id": 1,
+        "date": 1,
+        "from_id": 1,
+        "text": "short",
+        "conversation_message_id": 42,
+        "fwd_messages": [],
+    }
+
+    message.update(data)
+    return ForeignMessageMin(
+        **message,
+        unprepared_ctx_api=ctx_api,
+        replace_mention=True,
+        group_id=1,
+    )
+
+
+def _make_api_with_callback(callback):
+    api = API("token")
+    api.http_client = MockedClient(callback=callback)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_get_full_message():
+    call_count = 0
+
+    def callback(method: str, url: str, data: dict):
+        nonlocal call_count
+        if "messages.getByConversationMessageId" in url:
+            call_count += 1
+            return {
+                "response": {
+                    "count": 1,
+                    "items": [
+                        {
+                            "peer_id": 1,
+                            "date": 1,
+                            "from_id": 1,
+                            "text": "full message text with all attachments",
+                            "conversation_message_id": 42,
+                            "id": 100,
+                            "out": 0,
+                            "version": 1,
+                            "fwd_messages": [],
+                            "attachments": [],
+                        }
+                    ],
+                }
+            }
+
+    api = _make_api_with_callback(callback)
+    msg = fake_foreign_message(api, text="short")
+
+    result = await msg.get_full_message()
+
+    assert result is msg
+    assert msg.text == "full message text with all attachments"
+    assert msg._is_full is True
+    assert call_count == 1
+
+    # Second call should use cache
+    result2 = await msg.get_full_message()
+    assert result2 is msg
+    assert call_count == 1  # No additional API call
+
+
+@pytest.mark.asyncio
+async def test_get_full_message_with_explicit_peer_id():
+    captured_data = {}
+
+    def callback(method: str, url: str, data: dict):
+        if "messages.getByConversationMessageId" in url:
+            captured_data.update(data)
+            return {
+                "response": {
+                    "count": 1,
+                    "items": [
+                        {
+                            "peer_id": 999,
+                            "date": 1,
+                            "from_id": 1,
+                            "text": "full text",
+                            "conversation_message_id": 42,
+                            "id": 100,
+                            "out": 0,
+                            "version": 1,
+                            "fwd_messages": [],
+                        }
+                    ],
+                }
+            }
+
+    api = _make_api_with_callback(callback)
+    msg = fake_foreign_message(api, text="short", peer_id=1)
+
+    await msg.get_full_message(peer_id=999)
+
+    assert captured_data["peer_id"] == 999


### PR DESCRIPTION
Какую проблему решает ваш PR:
> ForeignMessageMin (объект пересланного/ответного сообщения в reply_message и fwd_messages) не имеет метода get_full_message(), хотя у MessageMin он есть
> 
> Из-за этого невозможно получить полные данные пересланного сообщения (attachments, полный текст) через API - приходилось вручную вызывать messages.getByConversationMessageId и самостоятельно обновлять объект

Добавлен `get_full_message(peer_id=None)` в BaseForeignMessageMin (делает его автоматически доступным и в bot, и в user реализациях). Метод работает аналогично `MessageMin.get_full_message()`, загружает полное сообщение -> обновляет текущий объект -> кэширует результат

Связанные issue: #1166 

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [x] Для вашего кода есть примеры использования в examples.
