### PR TITLE
fix: correct offset propagation for 3+ nested Format objects

### DIFF
--- a/tests/tools/test_formatting.py
+++ b/tests/tools/test_formatting.py
@@ -243,3 +243,26 @@ def test_functional_equivalence():
     funcs_8 = "こんにちは (" + italic(japanize) + ") 🌸"
     formatter_8 = Formatter("こんにちは ({japanize:italic}) 🌸").format_map({"japanize": japanize})
     assert funcs_8.as_data() == formatter_8.format_data
+
+
+def test_nested_format_offset_propagation():
+    sample = "Плоский текст " + url(underline(bold("жирная ссылка")), href="https://example.com")
+
+    data = sample.as_data()
+    items = {item["type"]: item for item in data["items"]}
+
+    assert items["bold"]["offset"] == 14
+    assert items["underline"]["offset"] == 14
+    assert items["url"]["offset"] == 14
+    assert items["bold"]["length"] == 13
+    assert items["underline"]["length"] == 13
+
+
+def test_two_level_nesting_works():
+    sample = "Плоский текст " + url(bold("жирная ссылка"), href="https://example.com")
+
+    data = sample.as_data()
+    items = {item["type"]: item for item in data["items"]}
+
+    assert items["bold"]["offset"] == 14
+    assert items["url"]["offset"] == 14

--- a/vkbottle/tools/formatting.py
+++ b/vkbottle/tools/formatting.py
@@ -82,14 +82,18 @@ class Format:
             return NotImplemented
         return self.add_other(other)
 
+    def _add_offset_recursive(self, formats: list[typing.Self], offset: int) -> None:
+        for fmt in formats:
+            fmt.offset += offset
+            self._add_offset_recursive(fmt.other_formats, offset)
+
     def __radd__(self, other: object, /) -> typing.Self:
         if not isinstance(other, str):
             return NotImplemented
         if isinstance(other, str):
             rhs_offset = _calculate_offset(other)
             self.offset += rhs_offset
-            for other_format in self.other_formats:
-                other_format.offset += rhs_offset
+            self._add_offset_recursive(self.other_formats, rhs_offset)
             self.string = other + self.string
             return self
 
@@ -99,8 +103,7 @@ class Format:
     def add_other(self, other: typing.Self, /) -> typing.Self:
         rhs_offset = _calculate_offset(self.string)
         other.offset += rhs_offset
-        for other_format in other.other_formats:
-            other_format.offset += rhs_offset
+        self._add_offset_recursive(other.other_formats, rhs_offset)
 
         self.string += other.string
         self.other_formats.append(other)
@@ -128,7 +131,7 @@ class Format:
             return result
 
         for fmt in self.other_formats:
-            result["items"].extend(fmt.as_data(offset=offset)["items"])  # type: ignore
+            result["items"].extend(fmt.as_data(offset=0)["items"])  # type: ignore
 
         return result
 


### PR DESCRIPTION
Какую проблему решает ваш PR: Исправляет баг с некорректным распространением `offset` при вложенности 3+ `Format`-объектов.
Связанные issue: #1201

До фикса: при конкатенации `"текст " + url(underline(bold("ссылка")))` самый внутренний формат (`bold`) получал `offset=0` вместо `14`, из-за чего стиль «утекал» на соседний текст.

После фикса: `offset` рекурсивно применяется ко всем вложенным форматам, независимо от глубины.

Что изменено:
- Добавлен метод `_add_offset_recursive` в класс `Format` для корректного сдвига оффсетов на любой глубине вложенности
- Исправлена логика `as_data()`: дочерние форматы теперь получают `offset=0` относительно родителя, чтобы избежать двойного сдвига
- Добавлен тест `test_nested_format_offset_propagation` на регрессию

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
