### PR TITLE
fix(labeler): re-point loaded labeler's views to host

### DIFF
--- a/tests/tools/test_waiter_machine.py
+++ b/tests/tools/test_waiter_machine.py
@@ -2,7 +2,7 @@ import asyncio
 
 from tests.test_bot import fake_message
 from tests.test_utils import with_mocked_api
-from vkbottle.bot import rules
+from vkbottle.bot import BotLabeler, rules
 from vkbottle.dispatch.dispenser.builtin import BuiltinStateDispenser
 from vkbottle.dispatch.views.bot.message import BotMessageView
 from vkbottle.tools import WaiterMachine
@@ -58,3 +58,39 @@ async def test_waiter_machine(api) -> None:
     assert ctx == {}
     assert msg.peer_id == 11
     assert msg.text == "12345"
+
+
+@with_mocked_api(None)
+async def test_waiter_machine_with_loaded_labeler(api) -> None:
+    host = BotLabeler()
+    child = BotLabeler()
+
+    host.load(child)
+
+    state_dispenser = BuiltinStateDispenser()
+
+    wm = WaiterMachine()
+    trigger = fake_message(api, peer_id=11, text="/test")
+
+    async def deliver_next() -> None:
+        await asyncio.sleep(0)
+        await host.message_view.handle_event(
+            {
+                "type": "message_new",
+                "object": {
+                    "message": fake_message(api, peer_id=11, text="reply").__dict__,
+                },
+            },
+            api,
+            state_dispenser,
+        )
+
+    wait_task = asyncio.create_task(wm.wait(child.message_view, trigger))
+    deliver_task = asyncio.create_task(deliver_next())
+
+    msg, ctx = await asyncio.wait_for(wait_task, timeout=1.0)
+    await deliver_task
+
+    assert ctx == {}
+    assert msg.peer_id == 11
+    assert msg.text == "reply"

--- a/vkbottle/framework/labeler/base.py
+++ b/vkbottle/framework/labeler/base.py
@@ -176,13 +176,16 @@ class BaseLabeler(ABCLabeler, abc.ABC):
         return decorator  # type: ignore
 
     def load(self, labeler: "BaseLabeler"):
-        self.message_view.handlers.extend(labeler.message_view.handlers)
-        self.message_view.middlewares.extend(labeler.message_view.middlewares)
-        self.raw_event_view.middlewares.extend(labeler.raw_event_view.middlewares)
+        self.message_view.handlers.extend(list(labeler.message_view.handlers))
+        self.message_view.middlewares.extend(list(labeler.message_view.middlewares))
+        self.raw_event_view.middlewares.extend(list(labeler.raw_event_view.middlewares))
 
         for event, handler_basements in labeler.raw_event_view.handlers.items():
             event_handlers = self.raw_event_view.handlers.setdefault(event, [])
-            event_handlers.extend(handler_basements)
+            event_handlers.extend(list(handler_basements))
+
+        labeler.message_view = self.message_view
+        labeler.raw_event_view = self.raw_event_view
 
     def get_custom_rules(
         self,


### PR DESCRIPTION
**Какую проблему решает ваш PR:**
`BaseLabeler.load()` копирует `handlers`/`middlewares` из загружаемого лейблера, но не переподключает сами `labeler.message_view` / `raw_event_view` и после `bot.labeler.load(lb)` они продолжают указывать на отделенные view-объекты

PR переприсваивает `labeler.message_view` и `labeler.raw_event_view` после копирования, а также снапшотит исходные списки через `list(...)`, чтобы повторная загрузка одного и того же лейблера в разные хосты не каскадировала handlers и middlewares

**Связанные issue:** #1200.

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
