### PR TITLE
fix: skip empty longpoll updates and preserve ts

### DIFF
--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from tests.test_utils import MockedClient
-from vkbottle import API
+from vkbottle import API, ABCHTTPClient
 from vkbottle.polling.bot_polling import BotPolling
 
 EXAMPLE_EVENT = {
@@ -38,6 +38,62 @@ def make_bot_polling() -> tuple[BotPolling, API]:
 
     polling = BotPolling(api=api)
     return polling, api
+
+
+class TrackingClient(ABCHTTPClient):
+    def __init__(self) -> None:
+        self.longpoll_requests: list[dict[str, Any]] = []
+        self.longpoll_timeouts: list[Any] = []
+
+    async def request_text(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if "groups.getById" in url:
+            return {"response": {"groups": [{"id": 1}]}}
+        if "groups.getLongPollServer" in url:
+            return {"response": {"ts": 1, "server": "!SERVER!", "key": "key+with=sig"}}
+        return {}
+
+    async def request_json(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if url != "!SERVER!":
+            return {}
+
+        self.longpoll_requests.append(kwargs["params"])
+        self.longpoll_timeouts.append(kwargs["timeout"])
+        if len(self.longpoll_requests) == 1:
+            return {"ts": 2, "updates": []}
+        return {**EXAMPLE_EVENT, "ts": 3}
+
+    async def request_raw(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return {}
+
+    async def request_content(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> bytes:
+        return b""
+
+    async def close(self) -> None:
+        pass
 
 
 @pytest.mark.asyncio
@@ -85,3 +141,23 @@ async def test_stop_before_listen_is_noop():
         polling.stop()
 
     assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_updates_advance_ts_without_yielding():
+    """Empty longpoll responses should move ts but not be exposed as events."""
+
+    client = TrackingClient()
+    api = API("token")
+    api.http_client = client
+    polling = BotPolling(api=api, wait=25)
+
+    events = []
+    async for event in polling.listen():
+        events.append(event)
+        polling.stop()
+
+    assert events == [{**EXAMPLE_EVENT, "ts": 3}]
+    assert [request["ts"] for request in client.longpoll_requests] == [1, 2]
+    assert client.longpoll_requests[0]["key"] == "key+with=sig"
+    assert all(timeout.total == 35 for timeout in client.longpoll_timeouts)

--- a/vkbottle/polling/base.py
+++ b/vkbottle/polling/base.py
@@ -87,7 +87,7 @@ class BasePolling(ABCPolling, ABC):
 
                 server["ts"] = event["ts"]
                 retry_count = 0
-                if "updates" not in event:
+                if not event.get("updates"):
                     continue
                 yield event
             except (ClientConnectionError, asyncio.TimeoutError, VKAPIError[10]):

--- a/vkbottle/polling/bot_polling.py
+++ b/vkbottle/polling/bot_polling.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientTimeout
 from typing_extensions import Self
 
 from vkbottle.exception_factory import ErrorHandler
@@ -35,14 +36,16 @@ class BotPolling(BasePolling):
         # sourcery skip: use-fstring-for-formatting
         logger.debug("Making long request to get event with longpoll...")
         return await self.api.http_client.request_json(
-            url="{}?act=a_check&key={}&ts={}&wait={}&rps_delay={}".format(
-                server["server"],
-                server["key"],
-                server["ts"],
-                self.wait,
-                self.rps_delay,
-            ),
+            url=server["server"],
             method="POST",
+            params={
+                "act": "a_check",
+                "key": server["key"],
+                "ts": server["ts"],
+                "wait": self.wait,
+                "rps_delay": self.rps_delay,
+            },
+            timeout=ClientTimeout(total=self.wait + 10),
         )
 
     async def get_server(self) -> dict[str, Any]:

--- a/vkbottle/polling/user_polling.py
+++ b/vkbottle/polling/user_polling.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientTimeout
+
 from vkbottle.exception_factory import ErrorHandler
 from vkbottle.modules import logger
 
@@ -41,16 +43,18 @@ class UserPolling(BasePolling):
         # sourcery skip: use-fstring-for-formatting
         logger.debug("Making long request to get event with longpoll...")
         return await self.api.http_client.request_json(
-            url="https://{}?act=a_check&key={}&ts={}&wait={}&mode={}&rps_delay={}&version={}".format(
-                server["server"],
-                server["key"],
-                server["ts"],
-                self.wait,
-                self.mode,
-                self.rps_delay,
-                self.lp_version,
-            ),
+            url="https://{}".format(server["server"]),
             method="POST",
+            params={
+                "act": "a_check",
+                "key": server["key"],
+                "ts": server["ts"],
+                "wait": self.wait,
+                "mode": self.mode,
+                "rps_delay": self.rps_delay,
+                "version": self.lp_version,
+            },
+            timeout=ClientTimeout(total=self.wait + 10),
         )
 
     async def get_server(self) -> dict[str, Any]:


### PR DESCRIPTION
Какую проблему решает ваш PR:
Исправляет обработку пустых ответов Long Poll API: ответы с `updates: []` больше не считаются полученными событиями, но при этом корректно продвигают `ts`. Также long poll запросы теперь передают параметры через `params`, что безопаснее для `key`/`ts` со спецсимволами, и используют явный таймаут `wait + 10`.

Связанные issue: # .

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.