### PR TITLE
fix: retry user message fetch

### DIFF
--- a/tests/tools/test_user_message.py
+++ b/tests/tools/test_user_message.py
@@ -1,0 +1,61 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from vkbottle.tools.mini_types.user.message import message_min
+
+
+class Response:
+    def __init__(self, items: list[Any]) -> None:
+        self.items = items
+
+
+class MessageItem:
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "peer_id": 1,
+            "date": 1,
+            "from_id": 1,
+            "text": "test",
+            "out": 0,
+            "id": 42,
+            "conversation_message_id": 1,
+            "version": 1,
+            "fwd_messages": [],
+        }
+
+
+class Messages:
+    def __init__(self, responses: list[Response]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_by_id(self, **data: Any) -> Response:
+        self.calls.append(data)
+        return self.responses.pop(0)
+
+
+class API:
+    def __init__(self, responses: list[Response]) -> None:
+        self.messages = Messages(responses)
+
+
+@pytest.mark.asyncio
+async def test_user_message_min_retries_empty_get_by_id_response() -> None:
+    api = API([Response([]), Response([MessageItem()])])
+
+    message = await message_min(42, api, fetch_attempts=2, fetch_retry_delay=0)
+
+    assert message.id == 42
+    assert api.messages.calls == [{"message_ids": [42]}, {"message_ids": [42]}]
+
+
+@pytest.mark.asyncio
+async def test_user_message_min_cancels_when_retries_are_exhausted() -> None:
+    api = API([Response([]), Response([])])
+
+    with pytest.raises(asyncio.CancelledError):
+        await message_min(42, api, fetch_attempts=2, fetch_retry_delay=0)
+
+    assert api.messages.calls == [{"message_ids": [42]}, {"message_ids": [42]}]

--- a/vkbottle/tools/mini_types/user/message.py
+++ b/vkbottle/tools/mini_types/user/message.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pydantic
 from vkbottle_types.objects import MessagesConversationMember
@@ -32,15 +32,36 @@ class MessageMin(BaseMessageMin):
 
 MessageMin.object_build(locals())
 
+MESSAGE_FETCH_ATTEMPTS: Final = 3
+MESSAGE_FETCH_RETRY_DELAY: Final = 0.1
+
 
 async def message_min(
     message_id: int,
     ctx_api: "ABCAPI",
     replace_mention: bool = True,
+    fetch_attempts: int = MESSAGE_FETCH_ATTEMPTS,
+    fetch_retry_delay: float = MESSAGE_FETCH_RETRY_DELAY,
 ) -> "MessageMin":
-    response = await ctx_api.messages.get_by_id(message_ids=[message_id])
+    response = None
 
-    if not response.items:
+    for attempt in range(1, fetch_attempts + 1):
+        response = await ctx_api.messages.get_by_id(message_ids=[message_id])
+
+        if response.items:
+            break
+
+        if attempt < fetch_attempts:
+            logger.debug(
+                "Message with id {} not found on attempt {}/{}, retrying after {} seconds.",
+                message_id,
+                attempt,
+                fetch_attempts,
+                fetch_retry_delay,
+            )
+            await asyncio.sleep(fetch_retry_delay)
+
+    if response is None or not response.items:
         logger.warning(f"Message with id {message_id} not found, perhaps it was deleted.")
         raise asyncio.CancelledError  # Cancel current task
 


### PR DESCRIPTION
Какую проблему решает ваш PR: Бывают момент, когда после проверки `messages.get_by_id` он становится пустым, хотя сообщение на самом деле существует, а сообщение может появиться в API после короткого тайминга. Такая проблема возникает редко, но всё же возникает, VK иногда отдаёт longpoll-событие раньше, чем сообщение становится доступно через API.

Именно для этого была создана система повторных попыток получения сообщения по ID. Сейчас количество попыток - 3, а задержка между попытками - 0.1 сек.

Связанные issue: # .

* [ ] Ваш код документирован.
* [X] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
