### PR TITLE
upd: Add `skip_old_events` for bot polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,8 @@ dmypy.json
 # pytest
 .pytest_cache
 
+# vkbottle local state
+.vkbottle/
+
 .vscode
 .vim

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,9 +1,10 @@
+import json
 from typing import Any
 
 import pytest
 
 from tests.test_utils import MockedClient
-from vkbottle import API, ABCHTTPClient
+from vkbottle import API, ABCHTTPClient, Bot
 from vkbottle.polling.bot_polling import BotPolling
 
 EXAMPLE_EVENT = {
@@ -15,6 +16,11 @@ EXAMPLE_EVENT = {
         },
     ],
 }
+
+
+@pytest.fixture(autouse=True)
+def polling_state_tmp_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
 
 
 def make_bot_polling() -> tuple[BotPolling, API]:
@@ -73,6 +79,60 @@ class TrackingClient(ABCHTTPClient):
         if len(self.longpoll_requests) == 1:
             return {"ts": 2, "updates": []}
         return {**EXAMPLE_EVENT, "ts": 3}
+
+    async def request_raw(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return {}
+
+    async def request_content(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> bytes:
+        return b""
+
+    async def close(self) -> None:
+        pass
+
+
+class OldEventsClient(ABCHTTPClient):
+    def __init__(self, server_ts: int, event_ts: int) -> None:
+        self.server_ts = server_ts
+        self.event_ts = event_ts
+        self.longpoll_requests: list[dict[str, Any]] = []
+
+    async def request_text(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if "groups.getById" in url:
+            return {"response": {"groups": [{"id": 1}]}}
+        if "groups.getLongPollServer" in url:
+            return {"response": {"ts": self.server_ts, "server": "!SERVER!", "key": ""}}
+        return {}
+
+    async def request_json(
+        self,
+        url: str,
+        method: str = "GET",
+        data: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if url != "!SERVER!":
+            return {}
+
+        self.longpoll_requests.append(kwargs["params"])
+        return {**EXAMPLE_EVENT, "ts": self.event_ts}
 
     async def request_raw(
         self,
@@ -161,3 +221,58 @@ async def test_empty_updates_advance_ts_without_yielding():
     assert [request["ts"] for request in client.longpoll_requests] == [1, 2]
     assert client.longpoll_requests[0]["key"] == "key+with=sig"
     assert all(timeout.total == 35 for timeout in client.longpoll_timeouts)
+
+
+def test_bot_passes_old_events_settings_to_polling():
+    bot = Bot(token="token", skip_old_events=False)
+
+    assert bot.skip_old_events is False
+    assert isinstance(bot.polling, BotPolling)
+    assert bot.polling.skip_old_events is False
+
+
+def test_bot_skips_old_events_by_default():
+    bot = Bot(token="token")
+
+    assert bot.skip_old_events is True
+    assert isinstance(bot.polling, BotPolling)
+    assert bot.polling.skip_old_events is True
+
+
+@pytest.mark.asyncio
+async def test_bot_polling_saves_ts_when_skipping_old_events():
+    client = OldEventsClient(server_ts=10, event_ts=11)
+    api = API("token")
+    api.http_client = client
+    polling = BotPolling(api=api)
+
+    async for _event in polling.listen():
+        polling.stop()
+
+    assert client.longpoll_requests[0]["ts"] == 10
+    assert json.loads(polling.ts_state_path.read_text(encoding="utf-8")) == {"ts": 11}
+
+
+@pytest.mark.asyncio
+async def test_bot_polling_restores_old_events_ts(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    first_client = OldEventsClient(server_ts=1, event_ts=2)
+    first_api = API("token")
+    first_api.http_client = first_client
+    first_polling = BotPolling(api=first_api, skip_old_events=False)
+
+    async for _event in first_polling.listen():
+        first_polling.stop()
+
+    assert first_client.longpoll_requests[0]["ts"] == 1
+
+    second_client = OldEventsClient(server_ts=10, event_ts=11)
+    second_api = API("token")
+    second_api.http_client = second_client
+    second_polling = BotPolling(api=second_api, skip_old_events=False)
+
+    async for _event in second_polling.listen():
+        second_polling.stop()
+
+    assert second_client.longpoll_requests[0]["ts"] == 2

--- a/vkbottle/framework/bot/bot.py
+++ b/vkbottle/framework/bot/bot.py
@@ -33,6 +33,7 @@ class Bot(BaseFramework):
         state_dispenser: "ABCStateDispenser | None" = None,
         error_handler: "ABCErrorHandler | None" = None,
         task_each_event: Any = None,
+        skip_old_events: bool = True,
     ) -> None:
         self.api: API = api or API(token)  # type: ignore
         self.error_handler = error_handler or ErrorHandler()
@@ -42,7 +43,16 @@ class Bot(BaseFramework):
         self.startup_tasks: list = []
         self.labeler = labeler or BotLabeler(error_handler=error_handler)
         self.state_dispenser = state_dispenser or BuiltinStateDispenser()
-        self._polling = polling or BotPolling(self.api, error_handler=error_handler)
+        self.skip_old_events = skip_old_events
+
+        if polling is not None and isinstance(polling, BotPolling):
+            polling.skip_old_events = skip_old_events
+
+        self._polling = polling or BotPolling(
+            self.api,
+            error_handler=error_handler,
+            skip_old_events=skip_old_events,
+        )
         self._callback = callback or BotCallback(error_handler=error_handler)
         self._router = router or Router()
 
@@ -75,7 +85,10 @@ class Bot(BaseFramework):
 
     @property
     def polling(self) -> "ABCPolling":
-        return self._polling.construct(self.api, self.error_handler)
+        polling = self._polling.construct(self.api, self.error_handler)
+        if isinstance(polling, BotPolling):
+            polling.skip_old_events = self.skip_old_events
+        return polling
 
     @property
     def router(self) -> "ABCRouter":

--- a/vkbottle/polling/base.py
+++ b/vkbottle/polling/base.py
@@ -28,6 +28,12 @@ class BasePolling(ABCPolling, ABC):
     error_handler: "ABCErrorHandler"
     lp_version: int | None = None
 
+    def restore_server_ts(self, server: dict[str, Any]) -> dict[str, Any]:
+        return server
+
+    def save_server_ts(self, server: dict[str, Any]) -> None:
+        pass
+
     async def handle_failed_event(
         self,
         server: dict[str, Any],
@@ -69,7 +75,7 @@ class BasePolling(ABCPolling, ABC):
     async def listen(self) -> AsyncGenerator[dict[str, Any], None]:
         self._stop_event = asyncio.Event()
         retry_count = 0
-        server = await self.get_server()
+        server = self.restore_server_ts(await self.get_server())
         logger.debug("Starting listening to {} longpoll", self.__class__.__name__)
 
         while not self._stop_event.is_set():
@@ -86,6 +92,7 @@ class BasePolling(ABCPolling, ABC):
                     continue
 
                 server["ts"] = event["ts"]
+                self.save_server_ts(server)
                 retry_count = 0
                 if not event.get("updates"):
                     continue

--- a/vkbottle/polling/bot_polling.py
+++ b/vkbottle/polling/bot_polling.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientTimeout
 from typing_extensions import Self
 
 from vkbottle.exception_factory import ErrorHandler
-from vkbottle.modules import logger
+from vkbottle.modules import json, logger
 
 from .base import BasePolling
 
@@ -24,6 +25,7 @@ class BotPolling(BasePolling):
         group_id: int | None = None,
         wait: int | None = None,
         rps_delay: int | None = None,
+        skip_old_events: bool = True,
         error_handler: "ABCErrorHandler | None" = None,
     ) -> None:
         self._api = api
@@ -31,6 +33,48 @@ class BotPolling(BasePolling):
         self.group_id = group_id
         self.wait = min(wait or 25, 90)
         self.rps_delay = rps_delay or 0
+        self.skip_old_events = skip_old_events
+
+    @property
+    def ts_state_path(self) -> Path:
+        if self.group_id is None:
+            msg = "Bot polling state path is unavailable before group_id is resolved"
+            raise RuntimeError(msg)
+        return Path.cwd() / ".vkbottle" / "bot-polling" / f"{self.group_id}.json"
+
+    def restore_server_ts(self, server: dict[str, Any]) -> dict[str, Any]:
+        if self.skip_old_events:
+            return server
+
+        try:
+            with self.ts_state_path.open(encoding="utf-8") as f:
+                state = json.load(f)
+        except FileNotFoundError:
+            return server
+        except (OSError, TypeError, ValueError) as e:
+            logger.warning("Unable to load bot polling state from {}: {}", self.ts_state_path, e)
+            return server
+
+        ts = state.get("ts")
+        if ts is None:
+            return server
+
+        logger.info("Restoring bot polling ts {} from {}", ts, self.ts_state_path)
+        server["ts"] = ts
+        return server
+
+    def save_server_ts(self, server: dict[str, Any]) -> None:
+        path = self.ts_state_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = path.with_suffix(".tmp")
+        state = {"ts": server["ts"]}
+
+        try:
+            with temp_path.open("w", encoding="utf-8") as f:
+                json.dump(state, f)
+            temp_path.replace(path)
+        except OSError as e:
+            logger.warning("Unable to save bot polling state to {}: {}", path, e)
 
     async def get_event(self, server: dict[str, Any]) -> dict[str, Any]:
         # sourcery skip: use-fstring-for-formatting

--- a/vkbottle/polling/bot_polling.py
+++ b/vkbottle/polling/bot_polling.py
@@ -47,8 +47,7 @@ class BotPolling(BasePolling):
             return server
 
         try:
-            with self.ts_state_path.open(encoding="utf-8") as f:
-                state = json.load(f)
+            state = json.loads(self.ts_state_path.read_text(encoding="utf-8"))
         except FileNotFoundError:
             return server
         except (OSError, TypeError, ValueError) as e:
@@ -70,8 +69,11 @@ class BotPolling(BasePolling):
         state = {"ts": server["ts"]}
 
         try:
-            with temp_path.open("w", encoding="utf-8") as f:
-                json.dump(state, f)
+            payload: str | bytes = json.dumps(state)
+            if isinstance(payload, bytes):
+                temp_path.write_bytes(payload)
+            else:
+                temp_path.write_text(payload, encoding="utf-8")
             temp_path.replace(path)
         except OSError as e:
             logger.warning("Unable to save bot polling state to {}: {}", path, e)


### PR DESCRIPTION
Какую проблему решает ваш PR:
Теперь бот может сохранять последний `ts` LongPoll в локальный `.vkbottle/bot-polling/<group_id>.json` и при `skip_old_events=False` обрабатывать события, которые пришли во время простоя. По умолчанию `skip_old_events=True`, поэтому старое поведение сохраняется: старые события пропускаются, но актуальный `ts` всё равно записывается.

Связанные issue: # .

* [ ] Ваш код документирован.
* [x] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
